### PR TITLE
docs: align onboarding guidance with Node 22/24 policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 
 ### Dev Workflow
 - 前提: Node.js `22+`（推奨: `.nvmrc` の `24.x`）
+- 初回セットアップ: `nvm use && corepack enable && pnpm install`
 - 起動: `pnpm -C apps/webview-demo dev`
 - PM2起動: `pm2 start ecosystem.config.cjs`
 - 主要Lint/型チェック: 各パッケージの`package.json`参照。

--- a/README.ja.md
+++ b/README.ja.md
@@ -43,13 +43,17 @@ MarkBloom は、**Markdown を “真実のソース” のまま**、人間が 
 ## 依存関係モデル
 
 - app 層（`apps/*`）は core 層（`@yuya296/cm6-*`）に依存します。
+- `apps/vscode-extension` と `apps/webview-demo` は共通で次を利用します:
+  - `@yuya296/cm6-live-preview`
+  - `@yuya296/cm6-diff-gutter`
+  - `@yuya296/cm6-markdown-smart-bol`
 - `@yuya296/cm6-live-preview` は次を束ねます:
   - `@yuya296/cm6-live-preview-core`
   - `@yuya296/cm6-markdown-semantics`
   - `@yuya296/cm6-typography-theme`
-- `apps/vscode-extension` と `apps/webview-demo` は共通で次を利用します:
-  - `@yuya296/cm6-live-preview`
+  - `@yuya296/cm6-live-preview-mermaid`
   - `@yuya296/cm6-table`
+- `table` / `mermaid` は app 側の `livePreviewPreset` オプションで有効化します。
 
 図とリリース経路は `docs/architecture/overview.md` を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,17 @@ If Node is below the minimum version, `pnpm -C apps/webview-demo dev` fails earl
 ## Dependency model
 
 - App layer (`apps/*`) depends on core layer (`@yuya296/cm6-*`).
+- `apps/vscode-extension` and `apps/webview-demo` both use:
+  - `@yuya296/cm6-live-preview`
+  - `@yuya296/cm6-diff-gutter`
+  - `@yuya296/cm6-markdown-smart-bol`
 - `@yuya296/cm6-live-preview` composes:
   - `@yuya296/cm6-live-preview-core`
   - `@yuya296/cm6-markdown-semantics`
   - `@yuya296/cm6-typography-theme`
-- `apps/vscode-extension` and `apps/webview-demo` both use:
-  - `@yuya296/cm6-live-preview`
+  - `@yuya296/cm6-live-preview-mermaid`
   - `@yuya296/cm6-table`
+- `table` / `mermaid` are enabled via `livePreviewPreset` options in app wiring.
 
 For diagrams and release topology, see `docs/architecture/overview.md`.
 

--- a/docs/runbook/cicd.md
+++ b/docs/runbook/cicd.md
@@ -19,6 +19,7 @@
 ## CI (自動)
 - Trigger: `pull_request`, `push` (main)
 - workflow: `.github/workflows/ci.yml`
+- Node 実行バージョン: `22` と `24` の matrix
 - 実行内容（最小）
   - `pnpm install --frozen-lockfile`
   - `node scripts/check-compatibility.mjs`
@@ -31,6 +32,7 @@
 ## Webview Pages (自動公開)
 - 対象: `apps/webview-demo`
 - workflow: `.github/workflows/webview-pages.yml`
+- Node 実行バージョン: `24`
 - Trigger:
   - `push` (`main`) -> 最新断面を更新
   - `pull_request` (`opened`, `synchronize`, `reopened`) -> PR断面を更新
@@ -56,6 +58,7 @@
 
 ### Core release
 - workflow: `.github/workflows/core-release.yml`
+- Node 実行バージョン: `24`
 - 実行内容:
   - lockstep version 検証
   - `node scripts/check-compatibility.mjs`
@@ -66,6 +69,7 @@
 
 ### VS Code release
 - workflow: `.github/workflows/vscode-release.yml`
+- Node 実行バージョン: `24`
 - 実行内容:
   - extension version 検証
   - `node scripts/check-compatibility.mjs`
@@ -73,6 +77,12 @@
   - `pnpm -C apps/vscode-extension package|publish`
   - tag作成 (`vscode-vX.Y.Z`)
   - GitHub Release 作成（`release_notes/vscode.md` ベース）
+
+## Node 実行ポリシー
+- 開発の最小要件は `Node 22+`
+- 開発時の推奨バージョンは `.nvmrc` の `24`（`nvm use` を前提）
+- CI は互換性確認のため `22` / `24` 両方で実行する
+- 公開系 workflow（release / pages / audit）は `24` 固定で実行する
 
 ## Notes
 - main への push では publish しない

--- a/docs/runbook/development-ops.md
+++ b/docs/runbook/development-ops.md
@@ -1,8 +1,24 @@
 # 開発運用ルール (Development Ops)
 
 ## ブランチ運用
-- `main` のみを使用
+- `main` は保護ブランチとして扱い、直接作業しない
+- 作業ブランチを作成して開発する
+  - `feature/*`: 機能追加
+  - `fix/*`: 機能修正
+  - `docs/*`: ドキュメント修正
+  - `ci/*`: CI修正
 - 普段の push では publish しない
+
+## 初回セットアップ
+1) Node を `.nvmrc` に合わせる
+   - `nvm use`
+2) Corepack / pnpm を有効化する
+   - `corepack enable`
+   - `corepack prepare pnpm@10.27.0 --activate`
+3) 依存をインストールする
+   - `pnpm install`
+4) 開発サーバを起動する
+   - `pnpm -C apps/webview-demo dev`
 
 ## バージョン管理 (SemVer)
 - release line ごとに独立 SemVer を採用する

--- a/docs/runbook/devsecops.md
+++ b/docs/runbook/devsecops.md
@@ -20,6 +20,14 @@
 - `pnpm audit` を定期実行
 - 重大な脆弱性は publish 前に解消
 
+## Dependabot 運用
+- `.github/dependabot.yml` で自動更新を有効化する
+  - npm 依存 (`package-ecosystem: npm`): weekly
+  - GitHub Actions (`package-ecosystem: github-actions`): weekly
+- Dependabot PR のレビュー時は次を確認する
+  - CI が green（`22` / `24` matrix を含む）
+  - major 更新は release note と破壊的変更の有無を確認する
+
 ## OSS ライセンス
 - 依存ライセンスを定期確認（例: `pnpm licenses list` など）
 - ライセンスが未許可の場合は依存更新 or 除外


### PR DESCRIPTION
## 概要
Node 方針更新（22+/推奨24）に加えて、オンボーディング観点でドキュメント整合を実施しました。

## 反映内容
### Node 方針
- `.nvmrc` を `24` に変更
- `engines.node` を `>=22` に統一
- CI を Node `22` / `24` matrix に更新
- release/pages/audit workflow を Node `24` に更新

### オンボーディング整合（今回）
- `AGENTS.md`
  - 初回セットアップを明記（`nvm use && corepack enable && pnpm install`）
- `docs/runbook/development-ops.md`
  - ブランチ運用を AGENTS と一致
  - 初回セットアップ手順を追加
- `README.md` / `README.ja.md`
  - app の依存記載を実装準拠に修正（`cm6-live-preview` 経由で table/mermaid を有効化）
- `docs/runbook/cicd.md`
  - Node 実行ポリシー（CI:22/24、公開系:24、開発推奨:.nvmrc）を明文化
- `docs/runbook/devsecops.md`
  - Dependabot 運用（npm / GitHub Actions weekly）とレビュー観点を追加

## 検証
- `pnpm -C apps/webview-demo build`
- `rg` によるドキュメント矛盾ワードの確認
- `apps/*/package.json` と README 依存記述の一致確認
