### PR TITLE
[WIP] fix: table離脱後のArrowDown遷移とmermaid後gutterズレを修正

### DIFF
--- a/apps/webview-demo/index.html
+++ b/apps/webview-demo/index.html
@@ -41,6 +41,14 @@
               Block reveal
             </label>
             <label class="control-item">
+              <input id="toggle-mermaid" type="checkbox" checked />
+              Mermaid
+            </label>
+            <label class="control-item">
+              <input id="toggle-table" type="checkbox" checked />
+              Table
+            </label>
+            <label class="control-item">
               Tab size
               <input id="tab-size" type="number" min="2" max="8" value="4" />
             </label>

--- a/apps/webview-demo/src/app.ts
+++ b/apps/webview-demo/src/app.ts
@@ -13,6 +13,8 @@ type ExtensionOptions = {
   tabSize: number;
   livePreviewEnabled: boolean;
   blockRevealEnabled: boolean;
+  mermaidEnabled: boolean;
+  tableEnabled: boolean;
   diffBaselineText: string;
 };
 
@@ -33,6 +35,8 @@ function buildExtensions({
   tabSize,
   livePreviewEnabled,
   blockRevealEnabled,
+  mermaidEnabled,
+  tableEnabled,
   diffBaselineText,
 }: ExtensionOptions): Extension[] {
   const extensions: Extension[] = [];
@@ -68,8 +72,8 @@ function buildExtensions({
             imageRawShowsPreview: true,
           }
         : false,
-      mermaid: livePreviewEnabled,
-      table: true,
+      mermaid: livePreviewEnabled && mermaidEnabled,
+      table: tableEnabled,
     })
   );
 
@@ -90,6 +94,8 @@ export function setupApp() {
     wrap: document.getElementById("toggle-wrap"),
     livePreview: document.getElementById("toggle-live-preview"),
     blockReveal: document.getElementById("toggle-block-reveal"),
+    mermaid: document.getElementById("toggle-mermaid"),
+    table: document.getElementById("toggle-table"),
     themeToggle: document.getElementById("toggle-theme"),
     tabSize: document.getElementById("tab-size"),
     apply: document.getElementById("apply"),
@@ -101,6 +107,8 @@ export function setupApp() {
     !(controls.wrap instanceof HTMLInputElement) ||
     !(controls.livePreview instanceof HTMLInputElement) ||
     !(controls.blockReveal instanceof HTMLInputElement) ||
+    !(controls.mermaid instanceof HTMLInputElement) ||
+    !(controls.table instanceof HTMLInputElement) ||
     !(controls.themeToggle instanceof HTMLButtonElement) ||
     !(controls.tabSize instanceof HTMLInputElement) ||
     !(controls.apply instanceof HTMLButtonElement)
@@ -112,6 +120,8 @@ export function setupApp() {
   const wrapControl = controls.wrap;
   const livePreviewControl = controls.livePreview;
   const blockRevealControl = controls.blockReveal;
+  const mermaidControl = controls.mermaid;
+  const tableControl = controls.table;
   const themeToggleControl = controls.themeToggle;
   const tabSizeControl = controls.tabSize;
   const applyControl = controls.apply;
@@ -143,6 +153,8 @@ export function setupApp() {
       wrapLines: wrapControl.checked,
       livePreviewEnabled: livePreviewControl.checked,
       blockRevealEnabled: blockRevealControl.checked,
+      mermaidEnabled: mermaidControl.checked,
+      tableEnabled: tableControl.checked,
       tabSize: Number(tabSizeControl.value),
       diffBaselineText: initialText,
     }),
@@ -155,6 +167,7 @@ export function setupApp() {
       }
     },
   });
+  (window as Window & { __MB_EDITOR_VIEW__?: EditorView }).__MB_EDITOR_VIEW__ = editor.view;
 
   const applyExtensions = () => {
     editor.setExtensions(
@@ -163,6 +176,8 @@ export function setupApp() {
         wrapLines: wrapControl.checked,
         livePreviewEnabled: livePreviewControl.checked,
         blockRevealEnabled: blockRevealControl.checked,
+        mermaidEnabled: mermaidControl.checked,
+        tableEnabled: tableControl.checked,
         tabSize: Number(tabSizeControl.value),
         diffBaselineText: initialText,
       })

--- a/apps/webview-demo/src/style.scss
+++ b/apps/webview-demo/src/style.scss
@@ -302,8 +302,18 @@ footer.footer {
   color: var(--editor-gutter-color);
 }
 
+.cm-editor .cm-scroller {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
 .cm-editor .cm-content {
-  padding: 12px;
+  padding: 0;
+}
+
+.cm-editor .cm-line {
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 .cm-editor .mb-syntax-secondary {

--- a/packages/core/cm6-live-preview-mermaid/src/mermaidWidget.ts
+++ b/packages/core/cm6-live-preview-mermaid/src/mermaidWidget.ts
@@ -184,6 +184,7 @@ class MermaidWidget extends WidgetType {
         error instanceof Error
           ? `Mermaid render error: ${error.message}`
           : "Mermaid render error";
+      MermaidWidget.requestEditorMeasure(wrapper);
     }
   }
 
@@ -226,8 +227,12 @@ class MermaidWidget extends WidgetType {
       cancelAnimationFrame(pending);
     }
     const frame = requestAnimationFrame(() => {
-      MermaidWidget.pendingMeasureFrames.delete(view);
       view.requestMeasure();
+      const settleFrame = requestAnimationFrame(() => {
+        MermaidWidget.pendingMeasureFrames.delete(view);
+        view.requestMeasure();
+      });
+      MermaidWidget.pendingMeasureFrames.set(view, settleFrame);
     });
     MermaidWidget.pendingMeasureFrames.set(view, frame);
   }

--- a/packages/core/cm6-table/src/index.ts
+++ b/packages/core/cm6-table/src/index.ts
@@ -1386,9 +1386,13 @@ class TableWidget extends WidgetType {
       }
       const target = view.state.doc.line(lineNumber);
       selection = null;
+      TableWidget.selectionMapForView(view).delete(this.tableInfo.key);
       applySelectionClasses();
       clearHoveredHandles();
       closeMenu();
+      if (document.activeElement === wrapper) {
+        wrapper.blur();
+      }
       dispatchOutsideSelection(view, target.from, true);
       return true;
     };
@@ -1783,6 +1787,7 @@ class TableWidget extends WidgetType {
         }
         if (!isEditing) {
           selection = null;
+          TableWidget.selectionMapForView(view).delete(this.tableInfo.key);
           applySelectionClasses();
           clearHoveredHandles();
         }
@@ -1823,13 +1828,16 @@ function dispatchOutsideUpdate(
 }
 
 function dispatchOutsideSelection(view: EditorView, anchor: number, focusEditor = false) {
-  if (focusEditor) {
-    view.focus();
-  }
   view.dispatch({
     selection: { anchor },
     scrollIntoView: true,
   });
+  if (focusEditor) {
+    view.focus();
+    requestAnimationFrame(() => {
+      view.focus();
+    });
+  }
 }
 
 function dispatchOutsideTransaction(

--- a/tests/e2e/table-mermaid-navigation-gutter.spec.cjs
+++ b/tests/e2e/table-mermaid-navigation-gutter.spec.cjs
@@ -1,0 +1,84 @@
+const { expect, test } = require("@playwright/test");
+
+async function setCursorByNeedle(page, needle, toLineEnd = false) {
+  await page.evaluate(
+    ({ text, toEnd }) => {
+      const view = window.__MB_EDITOR_VIEW__;
+      if (!view?.state) {
+        throw new Error("Missing __MB_EDITOR_VIEW__");
+      }
+      for (let n = 1; n <= view.state.doc.lines; n += 1) {
+        const line = view.state.doc.line(n);
+        if (!line.text.includes(text)) {
+          continue;
+        }
+        view.dispatch({
+          selection: { anchor: toEnd ? line.to : line.from },
+          scrollIntoView: true,
+        });
+        view.focus();
+        return;
+      }
+      throw new Error(`Needle not found: ${text}`);
+    },
+    { text: needle, toEnd: toLineEnd }
+  );
+}
+
+async function appendTokenAtLine(page, needle, token) {
+  await setCursorByNeedle(page, needle, true);
+  await page.keyboard.type(token);
+}
+
+async function measureMarkerDeltaByNeedle(page, needle) {
+  await setCursorByNeedle(page, needle, false);
+  return page.evaluate(() => {
+    const view = window.__MB_EDITOR_VIEW__;
+    if (!view?.state) {
+      throw new Error("Missing __MB_EDITOR_VIEW__");
+    }
+    const head = view.state.selection.main.head;
+    const line = view.state.doc.lineAt(head);
+    const coords = view.coordsAtPos(line.from);
+    if (!coords) {
+      throw new Error("Cannot resolve line coordinates");
+    }
+    const lineCenter = (coords.top + coords.bottom) / 2;
+    const markers = Array.from(
+      document.querySelectorAll(".cm-diff-gutter .cm-gutterElement")
+    ).filter((el) => el.querySelector(".cm-diff-marker"));
+    if (markers.length === 0) {
+      throw new Error("No diff markers found");
+    }
+
+    const nearest = markers
+      .map((el) => {
+        const rect = el.getBoundingClientRect();
+        const center = (rect.top + rect.bottom) / 2;
+        return { center, distance: Math.abs(center - lineCenter) };
+      })
+      .sort((a, b) => a.distance - b.distance)[0];
+
+    const delta = nearest.center - lineCenter;
+    return {
+      delta,
+      absDelta: Math.abs(delta),
+    };
+  });
+}
+
+test("diff gutter marker stays aligned after passing mermaid block", async ({ page }) => {
+  await page.goto("/");
+
+  const beforeToken = " [DRIFT-BEFORE]";
+  const afterToken = " [DRIFT-AFTER]";
+  await appendTokenAtLine(page, "A rich Markdown sample covering common patterns.", beforeToken);
+  await appendTokenAtLine(page, "End of sample.", afterToken);
+
+  const before = await measureMarkerDeltaByNeedle(page, "[DRIFT-BEFORE]");
+  const after = await measureMarkerDeltaByNeedle(page, "[DRIFT-AFTER]");
+
+  expect(before.absDelta).toBeLessThanOrEqual(3);
+  expect(after.absDelta).toBeLessThanOrEqual(3);
+  expect(Math.abs(after.delta - before.delta)).toBeLessThanOrEqual(2);
+});


### PR DESCRIPTION
## 概要
- table最下行から外へ出た後のArrowDown遷移を安定化
- mermaidレンダリング後の再計測を強化し、diff gutterの下方ズレを抑制
- webview-demoに mermaid / table の個別ON/OFFトグルを追加
- mermaid通過後のgutter整合をE2Eで追加

## 変更点
- `packages/core/cm6-table/src/index.ts`
  - table外遷移時にselectionMapを明示クリア
  - wrapper blur + editor focus復帰を安定化
- `packages/core/cm6-live-preview-mermaid/src/mermaidWidget.ts`
  - render成功/失敗の双方で再計測
  - 次フレーム再計測を追加
- `apps/webview-demo/src/style.scss`
  - 縦余白の適用箇所を`cm-scroller`基準に統一
- `apps/webview-demo/index.html` / `apps/webview-demo/src/app.ts`
  - Mermaid/Tableトグルを追加し拡張に配線
- `tests/e2e/table-mermaid-navigation-gutter.spec.cjs`
  - mermaid通過後のdiff marker位置整合テスト

## 動作確認
- `pnpm -C packages/core/cm6-table test`
- `pnpm -C apps/webview-demo build`
- `pnpm exec playwright test tests/e2e/*.spec.cjs`
