### PR TITLE
revert: failed releaseで入ったcore 0.3.0 bumpを取り消し

### DIFF
--- a/packages/core/cm6-diff-gutter/package.json
+++ b/packages/core/cm6-diff-gutter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-diff-gutter",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/cm6-live-preview-core/package.json
+++ b/packages/core/cm6-live-preview-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-live-preview-core",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/cm6-live-preview-mermaid/package.json
+++ b/packages/core/cm6-live-preview-mermaid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-live-preview-mermaid",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/cm6-live-preview/package.json
+++ b/packages/core/cm6-live-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-live-preview",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/cm6-markdown-semantics/package.json
+++ b/packages/core/cm6-markdown-semantics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-markdown-semantics",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/cm6-markdown-smart-bol/package.json
+++ b/packages/core/cm6-markdown-smart-bol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-markdown-smart-bol",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/cm6-table/package.json
+++ b/packages/core/cm6-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-table",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/core/cm6-typography-theme/package.json
+++ b/packages/core/cm6-typography-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya296/cm6-typography-theme",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- `main` に入ってしまった `chore(release): bump core packages to 0.3.0` をrevert
- core package version を `0.2.0` に戻す
- 失敗release runでタグは作成されていないため、削除対象タグなし

## Background
- run: https://github.com/yuya296/markbloom/actions/runs/23138844169
- `Publish core packages` が `EOTP` で失敗したが、その前段の `Commit and push bumped core versions` は成功しており、version bump commit だけが `main` に残っていた

## Verification
- `node scripts/check-compatibility.mjs`
