### PR TITLE
test(e2e): add diagnostic specs for cursor jump after table (#110)

### DIFF
--- a/apps/webview-demo/src/app.ts
+++ b/apps/webview-demo/src/app.ts
@@ -218,6 +218,7 @@ export function setupApp() {
       }
     },
   });
+  (window as Window & { __MB_EDITOR_VIEW__?: typeof editor.view }).__MB_EDITOR_VIEW__ = editor.view;
 
   const applyExtensions = () => {
     editor.setExtensions(buildExtensions(getExtensionOptions()));

--- a/tests/e2e/cursor-jump-after-table.spec.cjs
+++ b/tests/e2e/cursor-jump-after-table.spec.cjs
@@ -1,0 +1,65 @@
+const { expect, test } = require("@playwright/test");
+
+// Diagnostic spec for issue #110: ArrowDown after exiting a table sometimes
+// jumps to end-of-doc and oscillates between line 130 and 132.
+//
+// This was reproducible by hand but could not be reproduced under automation
+// at the time of writing (see issue thread for details). The spec is kept as
+// a soft-asserting watcher so that, if the regression resurfaces under the
+// timing patterns used here, CI logs will surface the trace.
+//
+// Requires `__MB_EDITOR_VIEW__` to be exposed on window — the webview-demo
+// app.ts publishes it as a debug helper.
+
+async function setCaretToLine(page, lineNumber) {
+  await page.evaluate((n) => {
+    const view = window.__MB_EDITOR_VIEW__;
+    if (!view) throw new Error("__MB_EDITOR_VIEW__ not available");
+    const ln = view.state.doc.line(n);
+    view.dispatch({ selection: { anchor: ln.from }, scrollIntoView: true });
+    view.focus();
+  }, lineNumber);
+}
+
+async function getCurrentLine(page) {
+  return page.evaluate(() => {
+    const view = window.__MB_EDITOR_VIEW__;
+    const head = view.state.selection.main.head;
+    return view.state.doc.lineAt(head).number;
+  });
+}
+
+test("ArrowDown should not jump to end-of-doc after exiting a table (issue #110)", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => Boolean(window.__MB_EDITOR_VIEW__));
+  await page.waitForTimeout(800);
+
+  const startLine = await page.evaluate(() => {
+    const view = window.__MB_EDITOR_VIEW__;
+    const doc = view.state.doc;
+    for (let i = 1; i <= doc.lines; i++) {
+      if (doc.line(i).text.startsWith("## Tables")) return i;
+    }
+    throw new Error("'## Tables' not found");
+  });
+
+  await setCaretToLine(page, startLine);
+  await page.waitForTimeout(200);
+  expect(await getCurrentLine(page)).toBe(startLine);
+
+  // Press ArrowDown enough times to traverse the table and the next 2 lines.
+  // Use varied delays to surface timing-dependent regressions.
+  const trace = [];
+  const expectedTotalLines = await page.evaluate(() => window.__MB_EDITOR_VIEW__.state.doc.lines);
+  const delays = [80, 80, 80, 200, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80];
+  for (const d of delays) {
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(d);
+    trace.push(await getCurrentLine(page));
+  }
+  console.log("trace:", trace.join(" -> "), "totalLines:", expectedTotalLines);
+
+  // Soft assert: cursor must NOT have jumped to end-of-doc (last line) early.
+  const jumped = trace.some((ln) => ln >= expectedTotalLines - 2);
+  expect.soft(jumped, `cursor reached end of doc unexpectedly: ${trace.join(",")}`).toBe(false);
+});

--- a/tests/e2e/cursor-jump-dev.spec.cjs
+++ b/tests/e2e/cursor-jump-dev.spec.cjs
@@ -1,0 +1,55 @@
+// Variant of cursor-jump-after-table.spec.cjs that targets the Vite dev server
+// (port 5173) instead of the static-build server (4174). Run with:
+//   pnpm -C apps/webview-demo dev   # in another terminal
+//   PWTEST_DEV=1 npx playwright test tests/e2e/cursor-jump-dev.spec.cjs --config tests/e2e/dev.config.cjs
+
+const { expect, test } = require("@playwright/test");
+
+async function setCaretToLine(page, lineNumber) {
+  await page.evaluate((n) => {
+    const view = window.__MB_EDITOR_VIEW__;
+    if (!view) throw new Error("__MB_EDITOR_VIEW__ not available");
+    const ln = view.state.doc.line(n);
+    view.dispatch({ selection: { anchor: ln.from }, scrollIntoView: true });
+    view.focus();
+  }, lineNumber);
+}
+
+async function getCurrentLine(page) {
+  return page.evaluate(() => {
+    const view = window.__MB_EDITOR_VIEW__;
+    const head = view.state.selection.main.head;
+    return view.state.doc.lineAt(head).number;
+  });
+}
+
+test("dev server: ArrowDown advances one line at a time after exiting a table", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => Boolean(window.__MB_EDITOR_VIEW__));
+  await page.waitForTimeout(1500);
+
+  const startLine = await page.evaluate(() => {
+    const view = window.__MB_EDITOR_VIEW__;
+    const doc = view.state.doc;
+    for (let i = 1; i <= doc.lines; i++) {
+      if (doc.line(i).text.startsWith("## Tables")) return i;
+    }
+    throw new Error("'## Tables' not found");
+  });
+
+  await setCaretToLine(page, startLine);
+  await page.waitForTimeout(200);
+
+  const trace = [];
+  const expectedTotalLines = await page.evaluate(() => window.__MB_EDITOR_VIEW__.state.doc.lines);
+  const delays = [80, 80, 80, 200, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80];
+  for (const d of delays) {
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(d);
+    trace.push(await getCurrentLine(page));
+  }
+  console.log("dev trace:", trace.join(" -> "), "totalLines:", expectedTotalLines);
+
+  const jumped = trace.some((ln) => ln >= expectedTotalLines - 2);
+  expect.soft(jumped, `cursor reached end of doc unexpectedly: ${trace.join(",")}`).toBe(false);
+});

--- a/tests/e2e/dev.config.cjs
+++ b/tests/e2e/dev.config.cjs
@@ -1,0 +1,15 @@
+// Playwright config that targets the running Vite dev server (no webServer
+// auto-start). Used by `cursor-jump-dev.spec.cjs` to reproduce timing-
+// dependent regressions that only show up under HMR.
+const { defineConfig } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./",
+  testMatch: /cursor-jump-dev\.spec\.cjs$/,
+  timeout: 30000,
+  expect: { timeout: 5000 },
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+});


### PR DESCRIPTION
## Summary

- Issue #110 (cursor jumps to end-of-doc after exiting a table) は **手動再現できたが自動再現には至らなかった**。本 PR では、再現条件を捕まえる足場として **Playwright 診断spec を 2 種類追加**する（build / dev 両環境）。
- spec は **soft assertion** で、現状は green だが、将来 regression が起きたときに CI ログに trace が残る運用。
- 併せて `webview-demo` の `EditorView` を `window.__MB_EDITOR_VIEW__` で公開（spec から view を直接操作するため。デバッグ helper 1 行）。

## Background

issue #111 (ArrowDown が table 直前行で数回反応しない) を調査する過程で、現象が **Table Boundary Navigation 仕様**（glossary 登録済み）であることが判明。一方 (#110) の末尾ジャンプは **自動操作では再現せず**、現状では root cause が掴めていない。状況は #110 にコメント済み:
https://github.com/yuya296/markbloom/issues/110

## Changes

- `apps/webview-demo/src/app.ts`: `__MB_EDITOR_VIEW__` を window に公開（debug helper, 1 行）
- `tests/e2e/cursor-jump-after-table.spec.cjs`: 静的 build 用 (port 4174)
- `tests/e2e/cursor-jump-dev.spec.cjs`: Vite dev 用 (port 5173)
- `tests/e2e/dev.config.cjs`: 上記 dev spec 用 config（既存 webServer に依存しない）

## Test plan

- [x] `pnpm -C apps/webview-demo lint`
- [x] `pnpm -C apps/webview-demo build`
- [x] `npx playwright test tests/e2e/cursor-jump-after-table.spec.cjs tests/e2e/core-regressions.spec.cjs` — all green
- [x] dev サーバ起動状態で `npx playwright test --config tests/e2e/dev.config.cjs` — green
- [x] `pnpm -C packages/core/cm6-table test` — 54 件全 pass

## Related

- Closes #111 (Table Boundary Navigation の仕様確認、非バグ判定)
- Refs #110 (Open のまま継続観察)
