### PR TITLE
fix(vscode-extension): cast Uri to string in template literals

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -307,7 +307,7 @@ class MarkBloomEditorProvider implements vscode.CustomTextEditorProvider {
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; img-src ${webview.cspSource} https: data:; style-src ${webview.cspSource} 'unsafe-inline' https:; font-src ${webview.cspSource} https: data:; script-src 'nonce-${nonce}';"
     />
-    ${cssUris.map((href) => `<link rel="stylesheet" href="${href}">`).join("\n    ")}
+    ${cssUris.map((href) => `<link rel="stylesheet" href="${href.toString()}">`).join("\n    ")}
     <title>MarkBloom Editor</title>
   </head>
   <body>
@@ -364,7 +364,7 @@ class MarkBloomEditorProvider implements vscode.CustomTextEditorProvider {
         <span id="change-info">No changes yet.</span>
       </footer>
     </div>
-    <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
+    <script type="module" nonce="${nonce}" src="${scriptUri.toString()}"></script>
   </body>
 </html>`;
   }


### PR DESCRIPTION
## Summary

`apps/vscode-extension/src/extension.ts` の `getHtmlForWebview` で、`webview.asWebviewUri` の戻り値（`vscode.Uri`）をテンプレートリテラルに直接埋め込んでいた箇所が2件あり、`@typescript-eslint/restrict-template-expressions` の lint エラーになっていた。

`Uri` は `toString()` を実装しており Webview URL を返すので、明示的に `.toString()` を呼んで型安全に統一する。ランタイム出力は不変。

## Changes

- src/extension.ts:310 — `<link rel="stylesheet" href="${href.toString()}">`
- src/extension.ts:367 — `<script ... src="${scriptUri.toString()}">`

## Test plan

- [x] `pnpm lint` (root) — green
- [x] `pnpm -C apps/vscode-extension typecheck` — green
- [x] `pnpm -C apps/vscode-extension build` — green
