### PR TITLE
fix(mermaid): switch to raw mode when caret enters the block (#112)

### DIFF
--- a/packages/core/cm6-live-preview-mermaid/src/mermaidPlugin.ts
+++ b/packages/core/cm6-live-preview-mermaid/src/mermaidPlugin.ts
@@ -33,9 +33,20 @@ export function mermaidLivePreviewPlugin(
         .map((range) => range.head);
 
       for (const block of blocks) {
+        // collapsed selection (caret) is intentionally excluded from
+        // ctx.isSelectionOverlap, so handle "caret strictly inside the
+        // block" here. Open interval (from, to):
+        // - `head === from` is treated as outside (caret right before the
+        //   opening fence; no need to enter raw mode yet).
+        // - `head === to` is treated as outside; the boundary right after
+        //   the closing fence is owned by `isCursorAtBottomBoundary`.
+        const cursorInsideBlock = cursorHeads.some(
+          (head) => head > block.rawJudgeRange.from && head < block.rawJudgeRange.to
+        );
         const isRaw =
           ctx.isSelectionOverlap(block.rawJudgeRange) ||
           ctx.isBlockRevealOverlap(block.rawJudgeRange) ||
+          cursorInsideBlock ||
           cursorHeads.some((head) => isCursorAtBottomBoundary(head, block));
         if (isRaw) {
           decorations.push({

--- a/packages/core/cm6-live-preview-mermaid/src/mermaidWidget.ts
+++ b/packages/core/cm6-live-preview-mermaid/src/mermaidWidget.ts
@@ -69,6 +69,13 @@ class MermaidWidget extends WidgetType {
     if (!wrapper.classList.contains(this.options.className)) {
       return false;
     }
+    // The wrapper class includes `cm-lp-mermaid-${mode}` (see toDOM).
+    // If the new widget has a different mode (replace ↔ append), we must
+    // not reuse the old DOM — return false so CodeMirror destroys the
+    // previous widget and calls toDOM with the new mode.
+    if (!wrapper.classList.contains(`cm-lp-mermaid-${this.options.mode}`)) {
+      return false;
+    }
     const container = wrapper.querySelector<HTMLElement>(".cm-lp-mermaid-content");
     const source = this.source.trim();
     if (!container) {

--- a/packages/core/cm6-live-preview-mermaid/tests/mermaidPlugin.test.ts
+++ b/packages/core/cm6-live-preview-mermaid/tests/mermaidPlugin.test.ts
@@ -75,3 +75,36 @@ test("does not switch to raw mode when cursor is at closing fence end", () => {
   assert.equal(decorations.length, 2);
   assert.ok(decorations.some((decoration) => decoration.from < decoration.to));
 });
+
+test("switches to raw mode when caret sits on the opening fence text", () => {
+  const plugin = mermaidLivePreviewPlugin();
+  const doc = ["```mermaid", "graph TD", "A-->B", "```", "after"].join("\n");
+  // caret 5 chars into "```mermaid" (between "`" and "mermaid")
+  const ctx = createContext(doc, { cursorPos: 5 });
+  const decorations = plugin.decorate(ctx);
+  assert.equal(decorations.length, 1);
+  assert.equal(decorations[0].from, decorations[0].to);
+});
+
+test("switches to raw mode when caret is on a body line inside the block", () => {
+  const plugin = mermaidLivePreviewPlugin();
+  const doc = ["```mermaid", "graph TD", "A-->B", "```", "after"].join("\n");
+  // caret on "graph TD" line
+  const cursorPos = doc.indexOf("graph TD") + 3;
+  const ctx = createContext(doc, { cursorPos });
+  const decorations = plugin.decorate(ctx);
+  assert.equal(decorations.length, 1);
+  assert.equal(decorations[0].from, decorations[0].to);
+});
+
+test("does not switch to raw mode when caret is exactly at block start (before opening fence)", () => {
+  const plugin = mermaidLivePreviewPlugin();
+  const doc = ["before", "```mermaid", "graph TD", "A-->B", "```", "after"].join("\n");
+  // caret at the position right before the opening fence (block.from)
+  const cursorPos = doc.indexOf("```mermaid");
+  const ctx = createContext(doc, { cursorPos });
+  const decorations = plugin.decorate(ctx);
+  // rich (replace + line mask)
+  assert.equal(decorations.length, 2);
+  assert.ok(decorations.some((decoration) => decoration.from < decoration.to));
+});

--- a/tests/e2e/diagnose-mermaid-toggle.spec.cjs
+++ b/tests/e2e/diagnose-mermaid-toggle.spec.cjs
@@ -1,0 +1,86 @@
+const { expect, test } = require("@playwright/test");
+
+// Regression watcher for issue #112 (mermaid raw/rich toggle when caret enters
+// the block). The mermaid feature flag is paused (off) by default in
+// `apps/webview-demo/src/featureFlags.ts`, so this spec auto-skips when no
+// mermaid widget is present in the DOM. Flip the flag to true to exercise it.
+//
+// Requires `__MB_EDITOR_VIEW__` to be exposed on window (debug helper that
+// the webview-demo app already publishes).
+
+async function setCaret(page, lineNum, col = 0) {
+  return page.evaluate(({ n, c }) => {
+    const view = window.__MB_EDITOR_VIEW__;
+    const ln = view.state.doc.line(n);
+    view.dispatch({ selection: { anchor: ln.from + c }, scrollIntoView: true });
+    view.focus();
+  }, { n: lineNum, c: col });
+}
+
+async function modeCounts(page) {
+  return page.evaluate(() => ({
+    replace: document.querySelectorAll(".cm-lp-mermaid-replace").length,
+    append: document.querySelectorAll(".cm-lp-mermaid-append").length,
+  }));
+}
+
+test("mermaid raw/rich toggle around block boundaries (issue #112)", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForFunction(() => Boolean(window.__MB_EDITOR_VIEW__));
+  await page.waitForTimeout(1500);
+
+  const mermaidStartLine = await page.evaluate(() => {
+    const view = window.__MB_EDITOR_VIEW__;
+    const doc = view.state.doc;
+    for (let i = 1; i <= doc.lines; i++) {
+      if (doc.line(i).text.startsWith("```mermaid")) return i;
+    }
+    return -1;
+  });
+  if (mermaidStartLine < 0) {
+    test.skip(true, "no mermaid block in sample doc");
+  }
+
+  // Place caret far away first; if the mermaid feature flag is off, no widget
+  // will be rendered and we cannot assert anything meaningful.
+  await setCaret(page, Math.max(1, mermaidStartLine - 5));
+  await page.waitForTimeout(200);
+  const baseline = await modeCounts(page);
+  if (baseline.replace === 0 && baseline.append === 0) {
+    test.skip(true, "mermaid feature flag is disabled (no widget in DOM)");
+  }
+
+  // Caret outside the block → rich (replace)
+  expect(baseline.replace).toBeGreaterThanOrEqual(1);
+  expect(baseline.append).toBe(0);
+
+  // Caret inside the block body → raw (append, no replace)
+  await setCaret(page, mermaidStartLine + 1);
+  await page.waitForTimeout(200);
+  const inside = await modeCounts(page);
+  expect.soft(inside.replace, `inside body should not show rich; counts=${JSON.stringify(inside)}`).toBe(0);
+  expect.soft(inside.append, `inside body should show append; counts=${JSON.stringify(inside)}`).toBeGreaterThanOrEqual(1);
+
+  // Caret on the opening fence line → raw
+  await setCaret(page, mermaidStartLine, 1);
+  await page.waitForTimeout(200);
+  const onOpen = await modeCounts(page);
+  expect.soft(onOpen.replace, `on opening fence should not show rich; counts=${JSON.stringify(onOpen)}`).toBe(0);
+  expect.soft(onOpen.append, `on opening fence should show append; counts=${JSON.stringify(onOpen)}`).toBeGreaterThanOrEqual(1);
+
+  // Caret moved far below → rich again
+  const closingLine = await page.evaluate((openLine) => {
+    const view = window.__MB_EDITOR_VIEW__;
+    const doc = view.state.doc;
+    for (let i = openLine + 1; i <= doc.lines; i++) {
+      if (doc.line(i).text.trim().startsWith("```")) return i;
+    }
+    return -1;
+  }, mermaidStartLine);
+  await setCaret(page, closingLine + 5);
+  await page.waitForTimeout(200);
+  const farBelow = await modeCounts(page);
+  // Note: the rendered region may be virtualized off-screen; only assert that
+  // the append (raw) widget no longer remains.
+  expect.soft(farBelow.append, `far below should not show append; counts=${JSON.stringify(farBelow)}`).toBe(0);
+});


### PR DESCRIPTION
## Summary

mermaid live-preview の rich → raw 切替が、caret を block 内に置いても発動しなかった (issue #112) のを修正。

原因は2層:

1. **caret (collapsed selection) は `selectionRanges` から除外されていた** (`cm6-live-preview-core/src/decorations.ts:53-55`)。よって `isSelectionOverlap(rawJudgeRange)` は caret 状態で常に false になり、isRaw 判定が失敗していた。
2. **`MermaidWidget.updateDOM` が mode 変化時にも `true` を返していた**。`mermaidBlockReplace` (rich) と `mermaidBlockWidget` (raw) は同じ `MermaidWidget` クラスを `mode` 違いで生成するため、CodeMirror は updateDOM が `true` を返すと既存 DOM を再利用してしまい、`cm-lp-mermaid-${mode}` class が古いまま残る → DOM 上 rich 表示が消えない。

## Changes

- `mermaidPlugin.ts`: isRaw 条件に **caret strictly inside `(from, to)`** を追加（既存の bottom boundary 判定はそのまま）
- `mermaidWidget.ts`: `updateDOM` で wrapper class が `cm-lp-mermaid-${currentMode}` を含まないなら `false` を返す（古い DOM を捨てて再生成）
- `mermaidPlugin.test.ts`: 新規ケース3件
  - caret on opening fence → raw
  - caret on body line → raw
  - caret at block.from (just before opening fence) → still rich
- `tests/e2e/diagnose-mermaid-toggle.spec.cjs`: regression watcher (mermaid flag off の時は auto-skip)

## Note on diagnosis

decorate の戻り値は最初から正しく raw を返していたが DOM が更新されないという症状で、debug log を仕込んでも原因が掴めなかった。CodeMirror 内部の widget 再利用ロジックが絡む点は **codex rescue agent に delegate** して特定。

## Test plan

- [x] `pnpm -C packages/core/cm6-live-preview-mermaid test` — 26件 pass (新規3件含む)
- [x] `pnpm typecheck` — green
- [x] `pnpm -C apps/webview-demo build` — green
- [x] `pnpm lint` — green
- [x] `npx playwright test` — 12 passed + 1 skipped (mermaid spec が flag OFF時 skip)
- [x] mermaid feature flag を一時 ON にして手動で playwright spec assertion 通過確認

## Closes

Closes #112
