### PR TITLE
fix(table): pull CM caret into the table on cell click (#110)

### DIFF
--- a/packages/core/cm6-table/src/index.ts
+++ b/packages/core/cm6-table/src/index.ts
@@ -1488,6 +1488,18 @@ class TableWidget extends WidgetType {
         event.stopPropagation();
         closeMenu();
         setSelection({ kind: "cell", row, col });
+        // Bring the CM caret into the table so that subsequent widget
+        // keydown handlers (and any external observers) see a CM
+        // selection consistent with the focused cell. Without this, a
+        // user who clicks a table cell while their CM caret is far away
+        // and then presses ArrowDown would teleport the caret to the
+        // table boundary line (issue #110).
+        const liveBoundary = getCurrentBoundary();
+        const cmHeadLine = view.state.doc.lineAt(view.state.selection.main.head).number;
+        if (cmHeadLine < liveBoundary.startLineNumber || cmHeadLine > liveBoundary.endLineNumber) {
+          const targetLine = view.state.doc.line(liveBoundary.startLineNumber);
+          dispatchOutsideSelection(view, targetLine.from);
+        }
       },
       { signal }
     );

--- a/packages/core/cm6-table/tests/tableEditor.integration.test.ts
+++ b/packages/core/cm6-table/tests/tableEditor.integration.test.ts
@@ -247,6 +247,54 @@ test("arrow down from last row moves caret to line after table", async () => {
   }
 });
 
+test("clicking a cell while CM caret is far away pulls the caret into the table (issue #110)", async () => {
+  const harness = await createTableEditorHarness(
+    [
+      "before",
+      "| A | B |",
+      "| --- | --- |",
+      "| 1 | 2 |",
+      "",
+      "after",
+      "trailing 1",
+      "trailing 2",
+      "trailing 3",
+    ].join("\n")
+  );
+  try {
+    const wrapper = harness.parent.querySelector<HTMLElement>(".cm6-table-editor");
+    assert.ok(wrapper);
+
+    // Place CM caret far away from the table (the last line).
+    const farLine = harness.view.state.doc.lines;
+    const farLineFrom = harness.view.state.doc.line(farLine).from;
+    harness.view.dispatch({ selection: { anchor: farLineFrom } });
+    await flushEditorUpdates();
+    assert.equal(harness.view.state.selection.main.head, farLineFrom);
+
+    // Click the last cell of the table.
+    clickCell(wrapper, 1, 1);
+    await flushEditorUpdates();
+
+    // CM caret should now be inside the table boundary (start line).
+    const tableStartLine = 2;
+    const expected = harness.view.state.doc.line(tableStartLine).from;
+    assert.equal(
+      harness.view.state.selection.main.head,
+      expected,
+      "CM caret should be pulled to the table start line after a cell click"
+    );
+
+    // ArrowDown from the last cell should jump to the line right after the
+    // table (line 5 in this fixture), not anywhere else.
+    dispatchKey(wrapper, "ArrowDown");
+    await flushEditorUpdates();
+    assert.equal(harness.view.state.selection.main.head, harness.view.state.doc.line(5).from);
+  } finally {
+    harness.teardown();
+  }
+});
+
 test("focusout clears all selection UI", async () => {
   const harness = await createTableEditorHarness(
     ["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n")


### PR DESCRIPTION
## 概要

issue #110（cell クリック後に ArrowDown を押すとカーソルがテーブル境界行へワープする問題）の修正。

### 真因

table widget の keydown ハンドラはウィジェット内のセル選択を一次情報として扱う。ユーザがセルをクリックすると `cm-table-editor` が DOM フォーカスを取得するが、**CodeMirror の selection は同期されず**、CM の caret は元の位置にとどまる。その状態で最初の ArrowDown を押すと、最終 row なら `moveSelectionOutsideTable(boundary.endLineNumber + 1)`、最初の row なら `boundary.startLineNumber - 1` 経路に入り、**`view.state.selection.main` を見ずに無条件で table 境界行に dispatch** してしまう。結果として CM caret は境界行にジャンプし、ユーザの直前の位置から大きく離れた場所に飛ぶ。

`playwright-cli` で実機操作したところ、以下の手順で 100% 再現：

```
init:           {h: 2265, ln: 131}                            # caret は table から遠い末尾近く
click cell '3': {h: 2265, ln: 131, ae: cm-table-editor}        # CM caret は不変、widget が DOM フォーカスを保持
ArrowDown 1x:   {h: 1975, ln: 105}                            # ← line 105 (table 直後) にワープ
```

### 修正

cell の `pointerdown` ハンドラ側で CM caret を同期する。`setSelection({kind:"cell", row, col})` の直後、`view.state.selection.main.head` が現在の table 境界の外にあれば、`dispatchOutsideSelection` で table 開始行に caret を置く（エディタ側にフォーカスは戻さず widget フォーカスは維持）。これ以降は widget 内 navigation と CM caret が常に整合するため、境界脱出 dispatch がユーザの想定通りの位置に着地する。

### テスト

- `packages/core/cm6-table/tests/tableEditor.integration.test.ts` に integration test を追加：
  > clicking a cell while CM caret is far away pulls the caret into the table (issue #110)

  click → ArrowDown のシーケンスを再現し、以下を assert：
  1. cell クリックで CM caret が table 内に入ること
  2. 最終 cell からの ArrowDown が table 直後の行に着地すること（それ以外の場所に飛ばないこと）

- 既存の 54 件は全て pass、合計 55 件。
- 既存の e2e 12 件も全 pass、診断 spec は mermaid feature flag が OFF の時 skip のまま。

## Test plan

- [x] `pnpm -C packages/core/cm6-table test`（新規 repro を含めて 55/55 pass）
- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm -C apps/webview-demo build` green
- [x] `npx playwright test`（12 passed + 1 skipped）
- [x] `pnpm dev` に対して `playwright-cli` で元の repro 経路を実機検証：
  - cell click → ArrowDown で境界行ワープが起きないこと
  - `## Tables` 行 → ArrowDown で従来通り 4 回目で table widget に入ること（Table Boundary Navigation の挙動は不変）

## Closes

Closes #110
