### PR TITLE
feat(mac): タイトルバーをエディタ背景と一体化させる (Typora 風)

### DIFF
--- a/apps/mac/index.html
+++ b/apps/mac/index.html
@@ -7,7 +7,10 @@
   </head>
   <body>
     <div id="app">
-      <div class="app-titlebar-drag-region" aria-hidden="true"></div>
+      <div class="app-titlebar" aria-hidden="true">
+        <div class="app-titlebar-traffic-light-spacer"></div>
+        <div class="app-titlebar-drag-area" data-tauri-drag-region></div>
+      </div>
       <div id="editor" class="editor"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/apps/mac/index.html
+++ b/apps/mac/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="app">
+      <div class="app-titlebar-drag-region" aria-hidden="true"></div>
       <div id="editor" class="editor"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/apps/mac/src-tauri/capabilities/default.json
+++ b/apps/mac/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-set-focus",
     "core:window:allow-show",
     "core:window:allow-hide",
+    "core:window:allow-start-dragging",
     "dialog:default"
   ]
 }

--- a/apps/mac/src-tauri/tauri.conf.json
+++ b/apps/mac/src-tauri/tauri.conf.json
@@ -16,7 +16,9 @@
         "title": "MarkBloom",
         "width": 1120,
         "height": 860,
-        "resizable": true
+        "resizable": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/apps/mac/src/app.ts
+++ b/apps/mac/src/app.ts
@@ -324,6 +324,8 @@ export function setupApp() {
           width: 1120,
           height: 860,
           resizable: true,
+          titleBarStyle: "overlay",
+          hiddenTitle: true,
           ...(position ? { x: position.x, y: position.y } : {}),
         });
         await win.once("tauri://error", (event) => {

--- a/apps/mac/src/style.scss
+++ b/apps/mac/src/style.scss
@@ -54,14 +54,29 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at 15% 10%, #ffffff, #fbfaf7 55%, #f4f2ec);
+  background: var(--app-surface);
   color: var(--app-text);
 }
+
+// Overlay title bar: the macOS title bar floats over the content.
+// Reserve top padding so the editor content doesn't disappear behind
+// the traffic-light buttons on the left, and treat that strip as a
+// drag region so the user can still move the window from there.
+$mac-title-bar-height: 28px;
 
 #app {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: var(--app-surface);
+}
+
+.app-titlebar-drag-region {
+  flex: 0 0 $mac-title-bar-height;
+  -webkit-app-region: drag;
+  // Leave room for the traffic-light buttons (left ~78px on macOS).
+  padding-left: 78px;
+  background: var(--app-surface);
 }
 
 .editor {

--- a/apps/mac/src/style.scss
+++ b/apps/mac/src/style.scss
@@ -51,6 +51,10 @@
   box-sizing: border-box;
 }
 
+// Paint html/body up to the very top so the macOS title bar area
+// (which we own via `titleBarStyle: "Overlay" + hiddenTitle: true`)
+// gets our color and never falls back to the OS active/inactive tint.
+html,
 body {
   margin: 0;
   min-height: 100vh;
@@ -58,32 +62,47 @@ body {
   color: var(--app-text);
 }
 
-// Overlay title bar: the macOS title bar floats over the content.
-// Reserve top padding so the editor content doesn't disappear behind
-// the traffic-light buttons on the left, and treat that strip as a
-// drag region so the user can still move the window from there.
+// Overlay title bar: macOS still draws the traffic-light buttons in
+// the top-left corner, but it does not paint a title bar background.
+// We reserve a strip across the full window width and ask Tauri to
+// treat the right portion as a drag region (drag / double-click-to-
+// zoom work as in any native window).
 $mac-title-bar-height: 28px;
+$mac-traffic-light-area: 78px;
 
 #app {
   min-height: 100vh;
+  background: var(--app-surface);
+}
+
+// Pin the title bar strip to the top of the window so it never scrolls
+// away with the editor content, and keep it above CodeMirror in the
+// stacking order so traffic lights stay clickable.
+.app-titlebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: $mac-title-bar-height;
   display: flex;
-  flex-direction: column;
   background: var(--app-surface);
+  z-index: 10;
 }
 
-.app-titlebar-drag-region {
-  flex: 0 0 $mac-title-bar-height;
-  -webkit-app-region: drag;
-  // Leave room for the traffic-light buttons (left ~78px on macOS).
-  padding-left: 78px;
-  background: var(--app-surface);
+.app-titlebar-traffic-light-spacer {
+  flex: 0 0 $mac-traffic-light-area;
 }
 
+.app-titlebar-drag-area {
+  flex: 1 1 auto;
+}
+
+// Push editor content below the fixed title bar so the macOS traffic
+// lights don't overlap document text.
 .editor {
-  flex: 1;
   width: 100%;
   background: var(--app-surface);
-  padding: 8px;
+  padding: $mac-title-bar-height 8px 8px;
 }
 
 .cm-editor,


### PR DESCRIPTION
## 概要

mac app のウィンドウタイトルバーが灰色のネイティブ装飾として浮き出て見える問題を、Typora 風の transparent / overlay タイトルバーで解消する。

## 背景

PR #119 (issue #104) のマルチウィンドウ対応を進める中で、ウィンドウ非アクティブ時にタイトルバー部分が灰色のネイティブ装飾として浮き出る見え方が気になった（エディタ部分の白背景とコントラストが出てしまう）。Typora や Bear など macOS のドキュメント編集アプリでは、タイトルバーが本文背景と一体化するのが定番。

## Changes

- `apps/mac/src-tauri/tauri.conf.json`: main window に `titleBarStyle: "Overlay"` と `hiddenTitle: true` を追加。OS タイトルバーがコンテンツ領域にオーバーレイされ、タイトル文字列も非表示になる。
- `apps/mac/src/app.ts`: `Cmd+N` で動的に作る webview にも同じ設定 (`titleBarStyle: "overlay"`, `hiddenTitle: true`) を渡す。
- `apps/mac/index.html` + `apps/mac/src/style.scss`: 上部に 28px の `.app-titlebar-drag-region` を追加。
  - エディタ本文がトラフィックライト（赤黄緑ボタン）の下に隠れないよう縦スペースを確保
  - 左 ~78px はトラフィックライトのために空ける
  - `-webkit-app-region: drag` を付けて、その帯をドラッグするとウィンドウを移動できるようにする
- `style.scss`: body の radial-gradient 背景は廃止し、`var(--app-surface)` の単色に統一。タイトルバー域・ドラッグ帯・エディタが同じ色で繋がる。

## Stacked on

このブランチは **#119 (feature/mac-multi-window) 上に積んで** いる。#119 が main にマージされたら、本 PR の base を main に切り替える or リベースして単独でマージ可能になる。

## Test plan

- [x] `pnpm -C apps/mac typecheck` green
- [x] `pnpm -C apps/mac lint` green
- [x] `pnpm -C apps/mac build` green
- [x] `cargo check` green
- [x] `tauri:dev` で実機検証:
  - [x] タイトル文字 (`sample.md — MarkBloom`) が表示されない
  - [x] タイトルバー帯がエディタ背景と一体化（灰色の浮きが消える）
  - [x] トラフィックライトボタンは左上にそのまま、機能する
  - [x] 上部 28px の帯をドラッグするとウィンドウが移動できる
  - [x] `Cmd+N` で開いた追加ウィンドウも同じ見た目になる
