### PR TITLE
refactor: app層のheading slug/smart-bolショートカット判定をcoreに集約 (#131)

### DIFF
--- a/apps/mac/src/createEditor.ts
+++ b/apps/mac/src/createEditor.ts
@@ -6,9 +6,10 @@ import { search, searchKeymap } from "@codemirror/search";
 import { markdown } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { GFM, Strikethrough } from "@lezer/markdown";
+import { findHeadingLineForId } from "@yuya296/cm6-live-preview";
 import {
+  getDefaultSmartBolShortcuts,
   markdownSmartBol,
-  type MarkdownSmartBolShortcut,
 } from "@yuya296/cm6-markdown-smart-bol";
 
 export type CreateEditorOptions = {
@@ -25,55 +26,6 @@ export type EditorHandle = {
   setExtensions: (nextExtensions?: Extension[]) => void;
   destroy: () => void;
 };
-
-function slugifyHeading(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s-]/gu, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-");
-}
-
-function findHeadingLineForId(view: EditorView, targetId: string) {
-  const used = new Map<string, number>();
-  for (let i = 1; i <= view.state.doc.lines; i += 1) {
-    const line = view.state.doc.line(i);
-    const match = line.text.match(/^\s{0,3}#{1,6}\s+(.+)$/);
-    if (!match) {
-      continue;
-    }
-    const headingText = match[1].replace(/\s+#*\s*$/, "");
-    const base = slugifyHeading(headingText);
-    if (!base) {
-      continue;
-    }
-    const count = used.get(base) ?? 0;
-    used.set(base, count + 1);
-    const id = count === 0 ? base : `${base}-${count}`;
-    if (id === targetId) {
-      return line;
-    }
-  }
-  return null;
-}
-
-function getDefaultSmartBolShortcuts(): readonly MarkdownSmartBolShortcut[] {
-  const platform =
-    (
-      navigator as Navigator & {
-        userAgentData?: { platform?: string };
-      }
-    ).userAgentData?.platform ??
-    navigator.platform ??
-    "";
-  const userAgent = navigator.userAgent ?? "";
-  const isMac = /Mac|iPhone|iPad|iPod/u.test(`${platform} ${userAgent}`);
-  if (isMac) {
-    return [{ mac: "Ctrl-a" }, { mac: "Cmd-ArrowLeft" }];
-  }
-  return [{ key: "Home" }];
-}
 
 export function createEditor({
   parent,
@@ -108,7 +60,7 @@ export function createEditor({
           event.preventDefault();
           event.stopPropagation();
           const targetId = decodeURIComponent(href.slice(1));
-          const targetLine = findHeadingLineForId(view, targetId);
+          const targetLine = findHeadingLineForId(view.state.doc, targetId);
           if (targetLine) {
             view.dispatch({
               selection: { anchor: targetLine.from },

--- a/apps/vscode-extension/webview/src/editor/createEditor.ts
+++ b/apps/vscode-extension/webview/src/editor/createEditor.ts
@@ -4,9 +4,10 @@ import { defaultKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { GFM, Strikethrough } from "@lezer/markdown";
+import { findHeadingLineForId } from "@yuya296/cm6-live-preview";
 import {
+  getDefaultSmartBolShortcuts,
   markdownSmartBol,
-  type MarkdownSmartBolShortcut,
 } from "@yuya296/cm6-markdown-smart-bol";
 
 export type CreateEditorOptions = {
@@ -22,55 +23,6 @@ export type EditorHandle = {
   setExtensions: (nextExtensions?: Extension[]) => void;
   destroy: () => void;
 };
-
-function slugifyHeading(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s-]/gu, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-");
-}
-
-function findHeadingLineForId(view: EditorView, targetId: string) {
-  const used = new Map<string, number>();
-  for (let i = 1; i <= view.state.doc.lines; i += 1) {
-    const line = view.state.doc.line(i);
-    const match = line.text.match(/^\s{0,3}#{1,6}\s+(.+)$/);
-    if (!match) {
-      continue;
-    }
-    const headingText = match[1].replace(/\s+#*\s*$/, "");
-    const base = slugifyHeading(headingText);
-    if (!base) {
-      continue;
-    }
-    const count = used.get(base) ?? 0;
-    used.set(base, count + 1);
-    const id = count === 0 ? base : `${base}-${count}`;
-    if (id === targetId) {
-      return line;
-    }
-  }
-  return null;
-}
-
-function getDefaultSmartBolShortcuts(): readonly MarkdownSmartBolShortcut[] {
-  const platform =
-    (
-      navigator as Navigator & {
-        userAgentData?: { platform?: string };
-      }
-    ).userAgentData?.platform ??
-    navigator.platform ??
-    "";
-  const userAgent = navigator.userAgent ?? "";
-  const isMac = /Mac|iPhone|iPad|iPod/u.test(`${platform} ${userAgent}`);
-  if (isMac) {
-    return [{ mac: "Ctrl-a" }, { mac: "Cmd-ArrowLeft" }];
-  }
-  return [{ key: "Home" }];
-}
 
 export function createEditor({
   parent,
@@ -105,7 +57,7 @@ export function createEditor({
           event.preventDefault();
           event.stopPropagation();
           const targetId = decodeURIComponent(href.slice(1));
-          const targetLine = findHeadingLineForId(view, targetId);
+          const targetLine = findHeadingLineForId(view.state.doc, targetId);
           if (targetLine) {
             view.dispatch({
               selection: { anchor: targetLine.from },

--- a/apps/webview-demo/src/createEditor.ts
+++ b/apps/webview-demo/src/createEditor.ts
@@ -4,9 +4,10 @@ import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { GFM, Strikethrough } from "@lezer/markdown";
+import { findHeadingLineForId } from "@yuya296/cm6-live-preview";
 import {
+  getDefaultSmartBolShortcuts,
   markdownSmartBol,
-  type MarkdownSmartBolShortcut,
 } from "@yuya296/cm6-markdown-smart-bol";
 
 export type CreateEditorOptions = {
@@ -22,55 +23,6 @@ export type EditorHandle = {
   setExtensions: (nextExtensions?: Extension[]) => void;
   destroy: () => void;
 };
-
-function slugifyHeading(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s-]/gu, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-");
-}
-
-function findHeadingLineForId(view: EditorView, targetId: string) {
-  const used = new Map<string, number>();
-  for (let i = 1; i <= view.state.doc.lines; i += 1) {
-    const line = view.state.doc.line(i);
-    const match = line.text.match(/^\s{0,3}#{1,6}\s+(.+)$/);
-    if (!match) {
-      continue;
-    }
-    const headingText = match[1].replace(/\s+#*\s*$/, "");
-    const base = slugifyHeading(headingText);
-    if (!base) {
-      continue;
-    }
-    const count = used.get(base) ?? 0;
-    used.set(base, count + 1);
-    const id = count === 0 ? base : `${base}-${count}`;
-    if (id === targetId) {
-      return line;
-    }
-  }
-  return null;
-}
-
-function getDefaultSmartBolShortcuts(): readonly MarkdownSmartBolShortcut[] {
-  const platform =
-    (
-      navigator as Navigator & {
-        userAgentData?: { platform?: string };
-      }
-    ).userAgentData?.platform ??
-    navigator.platform ??
-    "";
-  const userAgent = navigator.userAgent ?? "";
-  const isMac = /Mac|iPhone|iPad|iPod/u.test(`${platform} ${userAgent}`);
-  if (isMac) {
-    return [{ mac: "Ctrl-a" }, { mac: "Cmd-ArrowLeft" }];
-  }
-  return [{ key: "Home" }];
-}
 
 export function createEditor({
   parent,
@@ -105,7 +57,7 @@ export function createEditor({
           event.preventDefault();
           event.stopPropagation();
           const targetId = decodeURIComponent(href.slice(1));
-          const targetLine = findHeadingLineForId(view, targetId);
+          const targetLine = findHeadingLineForId(view.state.doc, targetId);
           if (targetLine) {
             view.dispatch({
               selection: { anchor: targetLine.from },

--- a/packages/core/cm6-live-preview/src/index.ts
+++ b/packages/core/cm6-live-preview/src/index.ts
@@ -8,6 +8,7 @@ import { markdownSemantics, type MarkdownSemanticsOptions } from "@yuya296/cm6-m
 import { tableEditor, type TableEditorOptions } from "@yuya296/cm6-table";
 import { typographyTheme, type TypographyThemeOptions } from "@yuya296/cm6-typography-theme";
 export { resolveImageBasePath } from "./imageBasePath";
+export { findHeadingLineForId } from "@yuya296/cm6-markdown-semantics";
 import type { LivePreviewPlugin } from "@yuya296/cm6-live-preview-core";
 
 type MermaidPresetOption = boolean | MermaidLivePreviewPluginOptions;

--- a/packages/core/cm6-markdown-semantics/src/index.ts
+++ b/packages/core/cm6-markdown-semantics/src/index.ts
@@ -1,5 +1,5 @@
 import { syntaxTree } from "@codemirror/language";
-import { RangeSetBuilder, type Extension } from "@codemirror/state";
+import { RangeSetBuilder, type Extension, type Line, type Text } from "@codemirror/state";
 import { Decoration, type DecorationSet, EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import type { SyntaxNode } from "@lezer/common";
 
@@ -91,6 +91,32 @@ export function slugifyHeading(text: string): string {
 
 export function stripHeadingMarkers(raw: string): string {
   return raw.replace(/^\s{0,3}#{1,6}\s+/, "").replace(/\s+#*\s*$/, "");
+}
+
+// ATX 見出し (`#`〜`######`) のみを対象に id (slug) と一致する行を返す。
+// 同一 slug が複数あるときは GFM と同じく `-1`, `-2` … のサフィックスで区別する。
+// Setext 見出しは Lezer の構文木側でしか判別できないため対象外。
+export function findHeadingLineForId(doc: Text, targetId: string): Line | null {
+  const used = new Map<string, number>();
+  for (let i = 1; i <= doc.lines; i += 1) {
+    const line = doc.line(i);
+    const match = line.text.match(/^\s{0,3}#{1,6}\s+(.+)$/);
+    if (!match) {
+      continue;
+    }
+    const headingText = match[1].replace(/\s+#*\s*$/, "");
+    const base = slugifyHeading(headingText);
+    if (!base) {
+      continue;
+    }
+    const count = used.get(base) ?? 0;
+    used.set(base, count + 1);
+    const id = count === 0 ? base : `${base}-${count}`;
+    if (id === targetId) {
+      return line;
+    }
+  }
+  return null;
 }
 
 function extractHeadingText(view: EditorView, from: number, to: number): string {

--- a/packages/core/cm6-markdown-semantics/tests/helpers.test.ts
+++ b/packages/core/cm6-markdown-semantics/tests/helpers.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Text } from "@codemirror/state";
 import type { SyntaxNode } from "@lezer/common";
 import {
   extractLinkHrefFromText,
+  findHeadingLineForId,
   getBlockquoteLevel,
   getListLevel,
   getTaskStateClassFromText,
@@ -63,4 +65,36 @@ test("counts blockquote nesting from current node and ancestors", () => {
   assert.equal(getBlockquoteLevel(createNode("Blockquote")), 1);
   assert.equal(getBlockquoteLevel(createNode("Blockquote", ["Blockquote", "Blockquote"])), 3);
   assert.equal(getBlockquoteLevel(null), 0);
+});
+
+test("findHeadingLineForId locates ATX heading by slug", () => {
+  const doc = Text.of([
+    "# Hello World",
+    "",
+    "body",
+    "## Hello World",
+    "",
+    "## 世界",
+  ]);
+  const first = findHeadingLineForId(doc, "hello-world");
+  assert.ok(first);
+  assert.equal(first?.number, 1);
+
+  const dup = findHeadingLineForId(doc, "hello-world-1");
+  assert.ok(dup);
+  assert.equal(dup?.number, 4);
+
+  const multilingual = findHeadingLineForId(doc, "世界");
+  assert.ok(multilingual);
+  assert.equal(multilingual?.number, 6);
+
+  assert.equal(findHeadingLineForId(doc, "missing"), null);
+});
+
+test("findHeadingLineForId ignores non-heading lines and respects trailing hashes", () => {
+  const doc = Text.of(["# title ##", "not a heading", "####### too deep"]);
+  const titled = findHeadingLineForId(doc, "title");
+  assert.ok(titled);
+  assert.equal(titled?.number, 1);
+  assert.equal(findHeadingLineForId(doc, "too-deep"), null);
 });

--- a/packages/core/cm6-markdown-smart-bol/src/index.ts
+++ b/packages/core/cm6-markdown-smart-bol/src/index.ts
@@ -59,6 +59,26 @@ function moveToMarkdownSmartBol(view: Parameters<Command>[0], extendSelection: b
   return true;
 }
 
+type NavigatorLike = {
+  userAgent?: string;
+  platform?: string;
+  userAgentData?: { platform?: string };
+};
+
+export function getDefaultSmartBolShortcuts(
+  nav?: NavigatorLike
+): readonly MarkdownSmartBolShortcut[] {
+  const resolved =
+    nav === undefined && typeof navigator !== "undefined" ? (navigator as NavigatorLike) : nav;
+  const platform = resolved?.userAgentData?.platform ?? resolved?.platform ?? "";
+  const userAgent = resolved?.userAgent ?? "";
+  const isMac = /Mac|iPhone|iPad|iPod/u.test(`${platform} ${userAgent}`);
+  if (isMac) {
+    return [{ mac: "Ctrl-a" }, { mac: "Cmd-ArrowLeft" }];
+  }
+  return [{ key: "Home" }];
+}
+
 export function markdownSmartBol(options: MarkdownSmartBolOptions = {}): Extension {
   const run: Command = (view) => moveToMarkdownSmartBol(view, false);
   const shift: Command = (view) => moveToMarkdownSmartBol(view, true);

--- a/packages/core/cm6-markdown-smart-bol/tests/smartBol.test.ts
+++ b/packages/core/cm6-markdown-smart-bol/tests/smartBol.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { getMarkdownSmartBolOffset } from "../src/index";
+import { getDefaultSmartBolShortcuts, getMarkdownSmartBolOffset } from "../src/index";
 
 test("heading: move after # markers", () => {
   assert.equal(getMarkdownSmartBolOffset("# Heading"), 2);
@@ -48,4 +48,39 @@ test("blockquote task list markers prioritize task side", () => {
 test("fallback to indentation for non target lines", () => {
   assert.equal(getMarkdownSmartBolOffset("plain text"), 0);
   assert.equal(getMarkdownSmartBolOffset("    plain text"), 4);
+});
+
+test("getDefaultSmartBolShortcuts returns Mac shortcuts when platform reports Mac", () => {
+  const shortcuts = getDefaultSmartBolShortcuts({ platform: "MacIntel", userAgent: "" });
+  assert.deepEqual(shortcuts, [{ mac: "Ctrl-a" }, { mac: "Cmd-ArrowLeft" }]);
+});
+
+test("getDefaultSmartBolShortcuts honors userAgentData over platform", () => {
+  const shortcuts = getDefaultSmartBolShortcuts({
+    platform: "Win32",
+    userAgent: "",
+    userAgentData: { platform: "Mac" },
+  });
+  assert.deepEqual(shortcuts, [{ mac: "Ctrl-a" }, { mac: "Cmd-ArrowLeft" }]);
+});
+
+test("getDefaultSmartBolShortcuts detects iOS via userAgent", () => {
+  const shortcuts = getDefaultSmartBolShortcuts({
+    platform: "",
+    userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+  });
+  assert.deepEqual(shortcuts, [{ mac: "Ctrl-a" }, { mac: "Cmd-ArrowLeft" }]);
+});
+
+test("getDefaultSmartBolShortcuts returns Home for non-Mac platforms", () => {
+  assert.deepEqual(getDefaultSmartBolShortcuts({ platform: "Win32", userAgent: "" }), [
+    { key: "Home" },
+  ]);
+  assert.deepEqual(getDefaultSmartBolShortcuts({ platform: "Linux x86_64", userAgent: "" }), [
+    { key: "Home" },
+  ]);
+});
+
+test("getDefaultSmartBolShortcuts returns Home for an empty navigator (no platform info)", () => {
+  assert.deepEqual(getDefaultSmartBolShortcuts({}), [{ key: "Home" }]);
 });


### PR DESCRIPTION
## Summary

- 3 つの app (webview-demo / mac / vscode-extension) の `createEditor.ts` に同一実装で重複していた `slugifyHeading` / `findHeadingLineForId` / `getDefaultSmartBolShortcuts` を core パッケージに集約
- 修正時の同期漏れリスクを排除し、core 側に単体テストを追加してカバレッジ向上

## 変更内容

- `@yuya296/cm6-markdown-semantics`: `findHeadingLineForId(doc: Text, targetId: string): Line | null` を追加 export。ATX 見出しのみ対象である旨を JSDoc コメントで明示
- `@yuya296/cm6-markdown-smart-bol`: `getDefaultSmartBolShortcuts(nav?: NavigatorLike)` を追加 export。テスト時に navigator を注入できるよう引数化
- `@yuya296/cm6-live-preview`: `findHeadingLineForId` を re-export（app は既に live-preview に依存しているため依存追加不要）
- app 3 つの `createEditor.ts`: ローカル定義を削除し core から import に差し替え
- core 単体テスト追加: 同名 slug カウンタ、多言語、Mac/Win/iOS/userAgentData/空 navigator など

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:core` (全パッケージのテストが通過)
- [x] `pnpm -C apps/webview-demo build` / `pnpm -C apps/webview-demo test:unit`
- [x] `pnpm check:compatibility`
- [x] pm2 起動 + Playwright 動作確認: トップページ表示・heading anchor リンクの行ジャンプ・smart-bol Ctrl+a 2 段階トグル すべて回帰なし
- [x] Codex による独立コードレビュー実施・指摘反映済み (live-preview バレルの re-export 範囲を最小化、JSDoc 追記)

Refs #130
Closes #131