### PR TITLE
refactor: webview-demo の createEditor / app.ts を責務単位に分離 (#132)

### DIFF
--- a/apps/webview-demo/src/app.ts
+++ b/apps/webview-demo/src/app.ts
@@ -1,232 +1,60 @@
-import { EditorState, Extension } from "@codemirror/state";
-import { lineNumbers, EditorView } from "@codemirror/view";
 import initialText from "../assets/sample.md?raw";
-import { diffGutter } from "@yuya296/cm6-diff-gutter";
-import { livePreviewPreset, resolveImageBasePath } from "@yuya296/cm6-live-preview";
 import { createEditor } from "./createEditor";
+import { buildExtensions } from "./editor/buildExtensions";
 import {
   type ExtensionOptions,
   readExtensionOptionsFromControls,
 } from "./editorSettings";
-import { editorTheme } from "./editorTheme";
-import { editorHighlightStyle } from "./editorHighlightStyle";
-import { resolveMermaidPreviewEnabled, resolvePreviewFeatureFlags } from "./featureFlags";
-
-function isTableLine(lineText: string): boolean {
-  const line = lineText.trim();
-  if (line.length === 0 || !line.includes("|")) {
-    return false;
-  }
-  if (/^\|?[-:\s]+(\|[-:\s]+)+\|?$/u.test(line)) {
-    return true;
-  }
-  return /^\|.*\|$/u.test(line);
-}
-
-function buildExtensions({
-  showLineNumbers,
-  wrapLines,
-  tabSize,
-  livePreviewEnabled,
-  blockRevealEnabled,
-  diffBaselineText,
-}: ExtensionOptions): Extension[] {
-  const extensions: Extension[] = [];
-  const previewFeatureFlags = resolvePreviewFeatureFlags();
-
-  extensions.push(
-    diffGutter({
-      baselineText: diffBaselineText,
-      ignoreLine: isTableLine,
-    })
-  );
-
-  if (showLineNumbers) {
-    extensions.push(lineNumbers());
-  }
-
-  if (wrapLines) {
-    extensions.push(EditorView.lineWrapping);
-  }
-
-  if (Number.isFinite(tabSize)) {
-    extensions.push(EditorState.tabSize.of(tabSize));
-  }
-
-  extensions.push(editorHighlightStyle());
-  extensions.push(editorTheme());
-
-  extensions.push(
-    livePreviewPreset({
-      livePreview: livePreviewEnabled
-        ? {
-            blockRevealEnabled,
-            imageBasePath: resolveImageBasePath(import.meta.env.BASE_URL),
-            imageRawShowsPreview: true,
-          }
-        : false,
-      // Mermaid is paused for now. Re-enable by flipping the feature flag.
-      mermaid: resolveMermaidPreviewEnabled({
-        livePreviewEnabled,
-        featureFlags: previewFeatureFlags,
-      }),
-      table: true,
-    })
-  );
-
-  return extensions;
-}
+import { queryAppControls } from "./ui/controls";
+import { createSettingsMenuController } from "./ui/settingsMenuController";
+import { createThemeController } from "./ui/themeController";
 
 export function setupApp() {
-  const editorHost = document.getElementById("editor");
-  const status = document.getElementById("status");
-  const changeInfo = document.getElementById("change-info");
-
-  if (!editorHost) {
-    throw new Error("Missing editor host element");
-  }
-
-  const controls = {
-    lineNumbers: document.getElementById("toggle-line-numbers"),
-    wrap: document.getElementById("toggle-wrap"),
-    livePreview: document.getElementById("toggle-live-preview"),
-    blockReveal: document.getElementById("toggle-block-reveal"),
-    themeToggle: document.getElementById("toggle-theme"),
-    tabSize: document.getElementById("tab-size"),
-    apply: document.getElementById("apply"),
-    settingsToggle: document.getElementById("settings-toggle"),
-    settingsPanel: document.getElementById("settings-panel"),
-  };
-
-  if (
-    !(controls.lineNumbers instanceof HTMLInputElement) ||
-    !(controls.wrap instanceof HTMLInputElement) ||
-    !(controls.livePreview instanceof HTMLInputElement) ||
-    !(controls.blockReveal instanceof HTMLInputElement) ||
-    !(controls.themeToggle instanceof HTMLButtonElement) ||
-    !(controls.tabSize instanceof HTMLInputElement) ||
-    !(controls.apply instanceof HTMLButtonElement) ||
-    !(controls.settingsToggle instanceof HTMLButtonElement) ||
-    !(controls.settingsPanel instanceof HTMLDivElement)
-  ) {
-    throw new Error("Missing control elements");
-  }
-
-  const lineNumbersControl = controls.lineNumbers;
-  const wrapControl = controls.wrap;
-  const livePreviewControl = controls.livePreview;
-  const blockRevealControl = controls.blockReveal;
-  const themeToggleControl = controls.themeToggle;
-  const tabSizeControl = controls.tabSize;
-  const applyControl = controls.apply;
-  const settingsToggleControl = controls.settingsToggle;
-  const settingsPanelControl = controls.settingsPanel;
-
-  const setSettingsMenuOpen = (open: boolean) => {
-    settingsToggleControl.setAttribute("aria-expanded", open ? "true" : "false");
-    settingsPanelControl.hidden = !open;
-  };
-
-  const isSettingsMenuOpen = () =>
-    settingsToggleControl.getAttribute("aria-expanded") === "true";
-
-  const syncTabSizeControl = (nextValue: string) => {
-    if (tabSizeControl.value !== nextValue) {
-      tabSizeControl.value = nextValue;
-    }
-  };
+  const controls = queryAppControls();
 
   const getExtensionOptions = (): ExtensionOptions => {
     const nextOptions = readExtensionOptionsFromControls({
-      showLineNumbers: lineNumbersControl.checked,
-      wrapLines: wrapControl.checked,
-      livePreviewEnabled: livePreviewControl.checked,
-      blockRevealEnabled: blockRevealControl.checked,
-      tabSizeInput: tabSizeControl.value,
+      showLineNumbers: controls.lineNumbers.checked,
+      wrapLines: controls.wrap.checked,
+      livePreviewEnabled: controls.livePreview.checked,
+      blockRevealEnabled: controls.blockReveal.checked,
+      tabSizeInput: controls.tabSize.value,
       diffBaselineText: initialText,
     });
-    syncTabSizeControl(nextOptions.normalizedTabSizeInput);
+    if (controls.tabSize.value !== nextOptions.normalizedTabSizeInput) {
+      controls.tabSize.value = nextOptions.normalizedTabSizeInput;
+    }
     return nextOptions;
   };
 
-  const setTheme = (nextTheme: "light" | "dark") => {
-    document.documentElement.dataset.theme = nextTheme;
-    themeToggleControl.setAttribute(
-      "aria-pressed",
-      nextTheme === "dark" ? "true" : "false"
-    );
-  };
+  createThemeController({ toggle: controls.themeToggle });
 
-  const prefersDark =
-    window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
-  setTheme(prefersDark ? "dark" : "light");
-  setSettingsMenuOpen(false);
-
-  themeToggleControl.addEventListener("click", () => {
-    const nextTheme =
-      document.documentElement.dataset.theme === "dark" ? "light" : "dark";
-    setTheme(nextTheme);
-  });
-
-  settingsToggleControl.addEventListener("click", () => {
-    const nextOpen = !isSettingsMenuOpen();
-    setSettingsMenuOpen(nextOpen);
-    if (nextOpen) {
-      lineNumbersControl.focus();
-    } else {
-      settingsToggleControl.focus();
-    }
-  });
-
-  settingsPanelControl.addEventListener("keydown", (event) => {
-    if (event.key !== "Escape") {
-      return;
-    }
-    event.preventDefault();
-    setSettingsMenuOpen(false);
-    settingsToggleControl.focus();
-  });
-
-  document.addEventListener("pointerdown", (event) => {
-    if (!isSettingsMenuOpen()) {
-      return;
-    }
-    if (!(event.target instanceof Node)) {
-      return;
-    }
-    if (
-      settingsPanelControl.contains(event.target) ||
-      settingsToggleControl.contains(event.target)
-    ) {
-      return;
-    }
-    event.preventDefault();
-    setSettingsMenuOpen(false);
-    settingsToggleControl.focus();
+  const settingsMenu = createSettingsMenuController({
+    toggle: controls.settingsToggle,
+    panel: controls.settingsPanel,
+    firstFocusable: controls.lineNumbers,
   });
 
   const editor = createEditor({
-    parent: editorHost,
+    parent: controls.editorHost,
     initialText,
     extensions: buildExtensions(getExtensionOptions()),
     onChange: (text) => {
-      if (status) {
-        status.textContent = `Length: ${text.length}`;
+      if (controls.status) {
+        controls.status.textContent = `Length: ${text.length}`;
       }
-      if (changeInfo) {
-        changeInfo.textContent = `Last change at ${new Date().toLocaleTimeString()}`;
+      if (controls.changeInfo) {
+        controls.changeInfo.textContent = `Last change at ${new Date().toLocaleTimeString()}`;
       }
     },
   });
-  (window as Window & { __MB_EDITOR_VIEW__?: typeof editor.view }).__MB_EDITOR_VIEW__ = editor.view;
+  (window as Window & { __MB_EDITOR_VIEW__?: typeof editor.view }).__MB_EDITOR_VIEW__ =
+    editor.view;
 
-  const applyExtensions = () => {
+  controls.apply.addEventListener("click", () => {
     editor.setExtensions(buildExtensions(getExtensionOptions()));
-    setSettingsMenuOpen(false);
-    settingsToggleControl.focus();
-  };
-
-  applyControl.addEventListener("click", applyExtensions);
+    settingsMenu.close();
+  });
 
   return editor;
 }

--- a/apps/webview-demo/src/createEditor.ts
+++ b/apps/webview-demo/src/createEditor.ts
@@ -1,14 +1,6 @@
-import { EditorState, Compartment, Extension, Prec } from "@codemirror/state";
-import { EditorView, keymap } from "@codemirror/view";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
-import { markdown } from "@codemirror/lang-markdown";
-import { languages } from "@codemirror/language-data";
-import { GFM, Strikethrough } from "@lezer/markdown";
-import { findHeadingLineForId } from "@yuya296/cm6-live-preview";
-import {
-  getDefaultSmartBolShortcuts,
-  markdownSmartBol,
-} from "@yuya296/cm6-markdown-smart-bol";
+import { Compartment, EditorState, type Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { createBaseExtensions } from "./editor/baseExtensions";
 
 export type CreateEditorOptions = {
   parent: HTMLElement;
@@ -35,74 +27,16 @@ export function createEditor({
   }
 
   const dynamicExtensions = new Compartment();
-  const baseExtensions = [
-    EditorView.domEventHandlers({
-      click: (event) => {
-        if (!(event.target instanceof HTMLElement)) {
-          return false;
-        }
-        const link = event.target.closest(".mb-link[data-href]");
-        if (!(link instanceof HTMLElement)) {
-          return false;
-        }
-        const href = link.dataset.href;
-        if (!href) {
-          return false;
-        }
-        const view = EditorView.findFromDOM(event.target);
-        if (!view) {
-          return false;
-        }
-        if (href.startsWith("#")) {
-          event.preventDefault();
-          event.stopPropagation();
-          const targetId = decodeURIComponent(href.slice(1));
-          const targetLine = findHeadingLineForId(view.state.doc, targetId);
-          if (targetLine) {
-            view.dispatch({
-              selection: { anchor: targetLine.from },
-              scrollIntoView: true,
-            });
-            return true;
-          }
-          return false;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-        window.open(href, "_blank", "noopener,noreferrer");
-        return true;
-      },
-    }),
-    history({
-      newGroupDelay: 1500,
-      joinToEvent: (tr, isAdjacent) => {
-        return isAdjacent || tr.docChanged;
-      },
-    }),
-    Prec.high(markdownSmartBol({ shortcuts: getDefaultSmartBolShortcuts() })),
-    keymap.of([...historyKeymap, ...defaultKeymap]),
-    markdown({
-      extensions: [Strikethrough, GFM],
-      codeLanguages: languages,
-    }),
-    EditorView.updateListener.of((update) => {
-      if (update.docChanged) {
-        onChange?.(update.state.doc.toString());
-      }
-    }),
-    dynamicExtensions.of(extensions),
-  ];
-
   const state = EditorState.create({
     doc: initialText,
-    extensions: baseExtensions,
+    extensions: createBaseExtensions({
+      dynamicCompartment: dynamicExtensions,
+      dynamicExtensions: extensions,
+      onChange,
+    }),
   });
 
-  const view = new EditorView({
-    state,
-    parent,
-  });
+  const view = new EditorView({ state, parent });
 
   return {
     view,

--- a/apps/webview-demo/src/editor/baseExtensions.ts
+++ b/apps/webview-demo/src/editor/baseExtensions.ts
@@ -1,0 +1,39 @@
+import { Compartment, Prec, type Extension } from "@codemirror/state";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { EditorView, keymap } from "@codemirror/view";
+import { markdown } from "@codemirror/lang-markdown";
+import { languages } from "@codemirror/language-data";
+import { GFM, Strikethrough } from "@lezer/markdown";
+import {
+  getDefaultSmartBolShortcuts,
+  markdownSmartBol,
+} from "@yuya296/cm6-markdown-smart-bol";
+import { linkClickHandler } from "./linkClickHandler";
+
+export type BaseExtensionsOptions = {
+  dynamicCompartment: Compartment;
+  dynamicExtensions: Extension[];
+  onChange?: (text: string) => void;
+};
+
+export function createBaseExtensions(opts: BaseExtensionsOptions): Extension[] {
+  return [
+    linkClickHandler(),
+    history({
+      newGroupDelay: 1500,
+      joinToEvent: (tr, isAdjacent) => isAdjacent || tr.docChanged,
+    }),
+    Prec.high(markdownSmartBol({ shortcuts: getDefaultSmartBolShortcuts() })),
+    keymap.of([...historyKeymap, ...defaultKeymap]),
+    markdown({
+      extensions: [Strikethrough, GFM],
+      codeLanguages: languages,
+    }),
+    EditorView.updateListener.of((update) => {
+      if (update.docChanged) {
+        opts.onChange?.(update.state.doc.toString());
+      }
+    }),
+    opts.dynamicCompartment.of(opts.dynamicExtensions),
+  ];
+}

--- a/apps/webview-demo/src/editor/buildExtensions.ts
+++ b/apps/webview-demo/src/editor/buildExtensions.ts
@@ -1,0 +1,34 @@
+import type { Extension } from "@codemirror/state";
+import { resolveImageBasePath } from "@yuya296/cm6-live-preview";
+import type { ExtensionOptions } from "../editorSettings";
+import { resolveMermaidPreviewEnabled, resolvePreviewFeatureFlags } from "../featureFlags";
+import {
+  buildDiffGutterExtension,
+  buildLineNumbersExtension,
+  buildLivePreviewExtension,
+  buildTabSizeExtension,
+  buildThemeExtensions,
+  buildWrapExtension,
+} from "./extensionBuilders";
+
+export function buildExtensions(options: ExtensionOptions): Extension[] {
+  const previewFeatureFlags = resolvePreviewFeatureFlags();
+  const mermaidEnabled = resolveMermaidPreviewEnabled({
+    livePreviewEnabled: options.livePreviewEnabled,
+    featureFlags: previewFeatureFlags,
+  });
+
+  return [
+    buildDiffGutterExtension({ baselineText: options.diffBaselineText }),
+    ...buildLineNumbersExtension({ showLineNumbers: options.showLineNumbers }),
+    ...buildWrapExtension({ wrapLines: options.wrapLines }),
+    ...buildTabSizeExtension({ tabSize: options.tabSize }),
+    ...buildThemeExtensions(),
+    buildLivePreviewExtension({
+      livePreviewEnabled: options.livePreviewEnabled,
+      blockRevealEnabled: options.blockRevealEnabled,
+      imageBaseUrl: resolveImageBasePath(import.meta.env.BASE_URL),
+      mermaidEnabled,
+    }),
+  ];
+}

--- a/apps/webview-demo/src/editor/extensionBuilders.ts
+++ b/apps/webview-demo/src/editor/extensionBuilders.ts
@@ -1,0 +1,49 @@
+import { EditorState, type Extension } from "@codemirror/state";
+import { EditorView, lineNumbers } from "@codemirror/view";
+import { diffGutter } from "@yuya296/cm6-diff-gutter";
+import { livePreviewPreset } from "@yuya296/cm6-live-preview";
+import { editorHighlightStyle } from "../editorHighlightStyle.ts";
+import { editorTheme } from "../editorTheme.ts";
+import { isTableLine } from "./tableLineMatcher.ts";
+
+export function buildDiffGutterExtension(opts: { baselineText: string }): Extension {
+  return diffGutter({
+    baselineText: opts.baselineText,
+    ignoreLine: isTableLine,
+  });
+}
+
+export function buildLineNumbersExtension(opts: { showLineNumbers: boolean }): Extension[] {
+  return opts.showLineNumbers ? [lineNumbers()] : [];
+}
+
+export function buildWrapExtension(opts: { wrapLines: boolean }): Extension[] {
+  return opts.wrapLines ? [EditorView.lineWrapping] : [];
+}
+
+export function buildTabSizeExtension(opts: { tabSize: number }): Extension[] {
+  return Number.isFinite(opts.tabSize) ? [EditorState.tabSize.of(opts.tabSize)] : [];
+}
+
+export function buildThemeExtensions(): Extension[] {
+  return [editorHighlightStyle(), editorTheme()];
+}
+
+export function buildLivePreviewExtension(opts: {
+  livePreviewEnabled: boolean;
+  blockRevealEnabled: boolean;
+  imageBaseUrl: string;
+  mermaidEnabled: boolean;
+}): Extension {
+  return livePreviewPreset({
+    livePreview: opts.livePreviewEnabled
+      ? {
+          blockRevealEnabled: opts.blockRevealEnabled,
+          imageBasePath: opts.imageBaseUrl,
+          imageRawShowsPreview: true,
+        }
+      : false,
+    mermaid: opts.mermaidEnabled,
+    table: true,
+  });
+}

--- a/apps/webview-demo/src/editor/linkClickHandler.ts
+++ b/apps/webview-demo/src/editor/linkClickHandler.ts
@@ -1,0 +1,68 @@
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { findHeadingLineForId } from "@yuya296/cm6-live-preview";
+
+export type LinkClickIntent =
+  | { kind: "anchor"; targetId: string }
+  | { kind: "external"; url: string }
+  | { kind: "ignore" };
+
+export function resolveLinkClickIntent(href: string | undefined | null): LinkClickIntent {
+  if (!href) {
+    return { kind: "ignore" };
+  }
+  if (href.startsWith("#")) {
+    const targetId = decodeURIComponent(href.slice(1));
+    return { kind: "anchor", targetId };
+  }
+  return { kind: "external", url: href };
+}
+
+export type LinkClickHandlerOptions = {
+  openExternal?: (url: string) => void;
+};
+
+function defaultOpenExternal(url: string) {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+export function linkClickHandler(options: LinkClickHandlerOptions = {}): Extension {
+  const openExternal = options.openExternal ?? defaultOpenExternal;
+  return EditorView.domEventHandlers({
+    click: (event) => {
+      if (!(event.target instanceof HTMLElement)) {
+        return false;
+      }
+      const link = event.target.closest(".mb-link[data-href]");
+      if (!(link instanceof HTMLElement)) {
+        return false;
+      }
+      const view = EditorView.findFromDOM(event.target);
+      if (!view) {
+        return false;
+      }
+      const intent = resolveLinkClickIntent(link.dataset.href);
+      if (intent.kind === "ignore") {
+        return false;
+      }
+      // ブラウザのフラグメント/外部ナビを早期に抑止する。
+      // 旧実装では `#xxx` クリックでアンカー未解決でも preventDefault していたため、
+      // 見出しが見つからないケースでも同等に抑止して回帰を避ける。
+      event.preventDefault();
+      event.stopPropagation();
+      if (intent.kind === "anchor") {
+        const targetLine = findHeadingLineForId(view.state.doc, intent.targetId);
+        if (!targetLine) {
+          return true;
+        }
+        view.dispatch({
+          selection: { anchor: targetLine.from },
+          scrollIntoView: true,
+        });
+        return true;
+      }
+      openExternal(intent.url);
+      return true;
+    },
+  });
+}

--- a/apps/webview-demo/src/editor/tableLineMatcher.ts
+++ b/apps/webview-demo/src/editor/tableLineMatcher.ts
@@ -1,0 +1,12 @@
+// `apps/mac/src/app.ts` と同等のロジック。
+// core 化は #130 系列の別 issue で扱う想定で、現時点では app 内に閉じる。
+export function isTableLine(lineText: string): boolean {
+  const line = lineText.trim();
+  if (line.length === 0 || !line.includes("|")) {
+    return false;
+  }
+  if (/^\|?[-:\s]+(\|[-:\s]+)+\|?$/u.test(line)) {
+    return true;
+  }
+  return /^\|.*\|$/u.test(line);
+}

--- a/apps/webview-demo/src/ui/controls.ts
+++ b/apps/webview-demo/src/ui/controls.ts
@@ -1,0 +1,49 @@
+export type AppControls = {
+  editorHost: HTMLElement;
+  status: HTMLElement | null;
+  changeInfo: HTMLElement | null;
+  lineNumbers: HTMLInputElement;
+  wrap: HTMLInputElement;
+  livePreview: HTMLInputElement;
+  blockReveal: HTMLInputElement;
+  themeToggle: HTMLButtonElement;
+  tabSize: HTMLInputElement;
+  apply: HTMLButtonElement;
+  settingsToggle: HTMLButtonElement;
+  settingsPanel: HTMLDivElement;
+};
+
+function requireElement<T extends Element>(
+  doc: Document,
+  id: string,
+  ctor: new () => T,
+  label: string
+): T {
+  const el = doc.getElementById(id);
+  if (!(el instanceof ctor)) {
+    throw new Error(`Missing or wrong type for control element: ${label} (#${id})`);
+  }
+  return el;
+}
+
+export function queryAppControls(doc: Document = document): AppControls {
+  const editorHost = doc.getElementById("editor");
+  if (!editorHost) {
+    throw new Error("Missing editor host element");
+  }
+
+  return {
+    editorHost,
+    status: doc.getElementById("status"),
+    changeInfo: doc.getElementById("change-info"),
+    lineNumbers: requireElement(doc, "toggle-line-numbers", HTMLInputElement, "lineNumbers"),
+    wrap: requireElement(doc, "toggle-wrap", HTMLInputElement, "wrap"),
+    livePreview: requireElement(doc, "toggle-live-preview", HTMLInputElement, "livePreview"),
+    blockReveal: requireElement(doc, "toggle-block-reveal", HTMLInputElement, "blockReveal"),
+    themeToggle: requireElement(doc, "toggle-theme", HTMLButtonElement, "themeToggle"),
+    tabSize: requireElement(doc, "tab-size", HTMLInputElement, "tabSize"),
+    apply: requireElement(doc, "apply", HTMLButtonElement, "apply"),
+    settingsToggle: requireElement(doc, "settings-toggle", HTMLButtonElement, "settingsToggle"),
+    settingsPanel: requireElement(doc, "settings-panel", HTMLDivElement, "settingsPanel"),
+  };
+}

--- a/apps/webview-demo/src/ui/settingsMenuController.ts
+++ b/apps/webview-demo/src/ui/settingsMenuController.ts
@@ -1,0 +1,89 @@
+export type SettingsMenuController = {
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  isOpen: () => boolean;
+  destroy: () => void;
+};
+
+export type SettingsMenuControllerOptions = {
+  toggle: HTMLButtonElement;
+  panel: HTMLDivElement;
+  firstFocusable: HTMLElement;
+  doc?: Document;
+};
+
+export function createSettingsMenuController(
+  options: SettingsMenuControllerOptions
+): SettingsMenuController {
+  const doc = options.doc ?? document;
+
+  const isOpen = () => options.toggle.getAttribute("aria-expanded") === "true";
+
+  const setOpen = (open: boolean) => {
+    options.toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    options.panel.hidden = !open;
+  };
+
+  const open = () => {
+    setOpen(true);
+    options.firstFocusable.focus();
+  };
+
+  const close = () => {
+    setOpen(false);
+    options.toggle.focus();
+  };
+
+  const toggle = () => {
+    if (isOpen()) {
+      close();
+    } else {
+      open();
+    }
+  };
+
+  const onToggleClick = () => toggle();
+
+  const onPanelKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") {
+      return;
+    }
+    event.preventDefault();
+    close();
+  };
+
+  const onDocumentPointerDown = (event: PointerEvent) => {
+    if (!isOpen()) {
+      return;
+    }
+    const target = event.target;
+    if (typeof Node !== "undefined" && !(target instanceof Node)) {
+      return;
+    }
+    if (target === null) {
+      return;
+    }
+    if (
+      options.panel.contains(target as Node) ||
+      options.toggle.contains(target as Node)
+    ) {
+      return;
+    }
+    event.preventDefault();
+    close();
+  };
+
+  setOpen(false);
+  options.toggle.addEventListener("click", onToggleClick);
+  options.panel.addEventListener("keydown", onPanelKeydown);
+  doc.addEventListener("pointerdown", onDocumentPointerDown);
+
+  const destroy = () => {
+    options.toggle.removeEventListener("click", onToggleClick);
+    options.panel.removeEventListener("keydown", onPanelKeydown);
+    doc.removeEventListener("pointerdown", onDocumentPointerDown);
+  };
+
+  return { open, close, toggle, isOpen, destroy };
+}

--- a/apps/webview-demo/src/ui/themeController.ts
+++ b/apps/webview-demo/src/ui/themeController.ts
@@ -1,0 +1,38 @@
+export type Theme = "light" | "dark";
+
+export type ThemeController = {
+  setTheme: (theme: Theme) => void;
+  toggle: () => void;
+  current: () => Theme;
+};
+
+export type ThemeControllerOptions = {
+  toggle: HTMLButtonElement;
+  root?: HTMLElement;
+  prefersDarkMatcher?: () => boolean;
+};
+
+function defaultPrefersDarkMatcher(): boolean {
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+}
+
+export function createThemeController(options: ThemeControllerOptions): ThemeController {
+  const root = options.root ?? document.documentElement;
+  const prefersDarkMatcher = options.prefersDarkMatcher ?? defaultPrefersDarkMatcher;
+
+  const setTheme = (theme: Theme) => {
+    root.dataset.theme = theme;
+    options.toggle.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
+  };
+
+  const current = (): Theme => (root.dataset.theme === "dark" ? "dark" : "light");
+
+  const toggle = () => {
+    setTheme(current() === "dark" ? "light" : "dark");
+  };
+
+  setTheme(prefersDarkMatcher() ? "dark" : "light");
+  options.toggle.addEventListener("click", toggle);
+
+  return { setTheme, toggle, current };
+}

--- a/apps/webview-demo/tests/extensionBuilders.test.ts
+++ b/apps/webview-demo/tests/extensionBuilders.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildLineNumbersExtension,
+  buildTabSizeExtension,
+  buildWrapExtension,
+} from "../src/editor/extensionBuilders.ts";
+
+test("buildLineNumbersExtension is empty when disabled", () => {
+  assert.deepEqual(buildLineNumbersExtension({ showLineNumbers: false }), []);
+});
+
+test("buildLineNumbersExtension returns one extension when enabled", () => {
+  const ext = buildLineNumbersExtension({ showLineNumbers: true });
+  assert.equal(ext.length, 1);
+});
+
+test("buildWrapExtension toggles by option", () => {
+  assert.deepEqual(buildWrapExtension({ wrapLines: false }), []);
+  assert.equal(buildWrapExtension({ wrapLines: true }).length, 1);
+});
+
+test("buildTabSizeExtension is empty when value is not finite", () => {
+  assert.deepEqual(buildTabSizeExtension({ tabSize: Number.NaN }), []);
+});
+
+test("buildTabSizeExtension returns one extension for finite size", () => {
+  assert.equal(buildTabSizeExtension({ tabSize: 4 }).length, 1);
+});
+

--- a/apps/webview-demo/tests/linkClickHandler.test.ts
+++ b/apps/webview-demo/tests/linkClickHandler.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveLinkClickIntent } from "../src/editor/linkClickHandler.ts";
+
+test("resolveLinkClickIntent returns ignore for nullish or empty href", () => {
+  assert.deepEqual(resolveLinkClickIntent(undefined), { kind: "ignore" });
+  assert.deepEqual(resolveLinkClickIntent(null), { kind: "ignore" });
+  assert.deepEqual(resolveLinkClickIntent(""), { kind: "ignore" });
+});
+
+test("resolveLinkClickIntent decodes anchor target id", () => {
+  assert.deepEqual(resolveLinkClickIntent("#hello-world"), {
+    kind: "anchor",
+    targetId: "hello-world",
+  });
+  assert.deepEqual(resolveLinkClickIntent("#%E3%81%82"), {
+    kind: "anchor",
+    targetId: "あ",
+  });
+});
+
+test("resolveLinkClickIntent treats bare # as anchor with empty target", () => {
+  // 旧実装は href が `#` だけでも preventDefault していたため、
+  // anchor 扱いで返して呼び出し側に preventDefault させる。
+  assert.deepEqual(resolveLinkClickIntent("#"), { kind: "anchor", targetId: "" });
+});
+
+test("resolveLinkClickIntent classifies any non-anchor href as external", () => {
+  assert.deepEqual(resolveLinkClickIntent("https://example.com/foo"), {
+    kind: "external",
+    url: "https://example.com/foo",
+  });
+  assert.deepEqual(resolveLinkClickIntent("/relative/path"), {
+    kind: "external",
+    url: "/relative/path",
+  });
+  assert.deepEqual(resolveLinkClickIntent("mailto:a@example.com"), {
+    kind: "external",
+    url: "mailto:a@example.com",
+  });
+});

--- a/apps/webview-demo/tests/settingsMenuController.test.ts
+++ b/apps/webview-demo/tests/settingsMenuController.test.ts
@@ -1,0 +1,166 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSettingsMenuController } from "../src/ui/settingsMenuController.ts";
+
+type Listener = (event: unknown) => void;
+
+function makeNode(opts: { contains?: (other: unknown) => boolean } = {}) {
+  const attrs = new Map<string, string>();
+  const listeners = new Map<string, Listener[]>();
+  const node = {
+    hidden: true,
+    focused: 0,
+    setAttribute(name: string, value: string) {
+      attrs.set(name, value);
+    },
+    getAttribute(name: string) {
+      return attrs.get(name) ?? null;
+    },
+    addEventListener(type: string, listener: Listener) {
+      const arr = listeners.get(type) ?? [];
+      arr.push(listener);
+      listeners.set(type, arr);
+    },
+    removeEventListener(type: string, listener: Listener) {
+      const arr = listeners.get(type) ?? [];
+      listeners.set(
+        type,
+        arr.filter((l) => l !== listener)
+      );
+    },
+    contains(other: unknown) {
+      return opts.contains ? opts.contains(other) : false;
+    },
+    focus() {
+      this.focused += 1;
+    },
+    dispatch(type: string, event: unknown) {
+      for (const l of listeners.get(type) ?? []) {
+        l(event);
+      }
+    },
+  };
+  return node;
+}
+
+function makeDoc() {
+  const listeners = new Map<string, Listener[]>();
+  return {
+    addEventListener(type: string, listener: Listener) {
+      const arr = listeners.get(type) ?? [];
+      arr.push(listener);
+      listeners.set(type, arr);
+    },
+    removeEventListener(type: string, listener: Listener) {
+      const arr = listeners.get(type) ?? [];
+      listeners.set(
+        type,
+        arr.filter((l) => l !== listener)
+      );
+    },
+    dispatch(type: string, event: unknown) {
+      for (const l of listeners.get(type) ?? []) {
+        l(event);
+      }
+    },
+  };
+}
+
+test("controller starts closed and exposes isOpen()", () => {
+  const toggle = makeNode();
+  const panel = makeNode();
+  const firstFocusable = makeNode();
+  const doc = makeDoc();
+  const ctrl = createSettingsMenuController({
+    toggle: toggle as unknown as HTMLButtonElement,
+    panel: panel as unknown as HTMLDivElement,
+    firstFocusable: firstFocusable as unknown as HTMLElement,
+    doc: doc as unknown as Document,
+  });
+  assert.equal(ctrl.isOpen(), false);
+  assert.equal(toggle.getAttribute("aria-expanded"), "false");
+  assert.equal(panel.hidden, true);
+});
+
+test("toggle click opens then closes the menu", () => {
+  const toggle = makeNode();
+  const panel = makeNode();
+  const firstFocusable = makeNode();
+  const doc = makeDoc();
+  const ctrl = createSettingsMenuController({
+    toggle: toggle as unknown as HTMLButtonElement,
+    panel: panel as unknown as HTMLDivElement,
+    firstFocusable: firstFocusable as unknown as HTMLElement,
+    doc: doc as unknown as Document,
+  });
+  toggle.dispatch("click", {});
+  assert.equal(ctrl.isOpen(), true);
+  assert.equal(panel.hidden, false);
+  assert.equal(firstFocusable.focused, 1);
+
+  toggle.dispatch("click", {});
+  assert.equal(ctrl.isOpen(), false);
+  assert.equal(toggle.focused, 1);
+});
+
+test("Escape on panel closes and refocuses toggle", () => {
+  const toggle = makeNode();
+  const panel = makeNode();
+  const firstFocusable = makeNode();
+  const doc = makeDoc();
+  const ctrl = createSettingsMenuController({
+    toggle: toggle as unknown as HTMLButtonElement,
+    panel: panel as unknown as HTMLDivElement,
+    firstFocusable: firstFocusable as unknown as HTMLElement,
+    doc: doc as unknown as Document,
+  });
+  ctrl.open();
+  let prevented = false;
+  panel.dispatch("keydown", {
+    key: "Escape",
+    preventDefault: () => {
+      prevented = true;
+    },
+  });
+  assert.equal(prevented, true);
+  assert.equal(ctrl.isOpen(), false);
+});
+
+test("outside pointerdown closes when open", () => {
+  const toggle = makeNode();
+  const panel = makeNode({ contains: () => false });
+  const firstFocusable = makeNode();
+  const doc = makeDoc();
+  const ctrl = createSettingsMenuController({
+    toggle: toggle as unknown as HTMLButtonElement,
+    panel: panel as unknown as HTMLDivElement,
+    firstFocusable: firstFocusable as unknown as HTMLElement,
+    doc: doc as unknown as Document,
+  });
+  ctrl.open();
+  let prevented = false;
+  doc.dispatch("pointerdown", {
+    target: { nodeType: 1 },
+    preventDefault: () => {
+      prevented = true;
+    },
+  });
+  assert.equal(prevented, true);
+  assert.equal(ctrl.isOpen(), false);
+});
+
+test("destroy removes registered listeners", () => {
+  const toggle = makeNode();
+  const panel = makeNode();
+  const firstFocusable = makeNode();
+  const doc = makeDoc();
+  const ctrl = createSettingsMenuController({
+    toggle: toggle as unknown as HTMLButtonElement,
+    panel: panel as unknown as HTMLDivElement,
+    firstFocusable: firstFocusable as unknown as HTMLElement,
+    doc: doc as unknown as Document,
+  });
+  ctrl.destroy();
+  toggle.dispatch("click", {});
+  assert.equal(ctrl.isOpen(), false);
+});

--- a/apps/webview-demo/tests/tableLineMatcher.test.ts
+++ b/apps/webview-demo/tests/tableLineMatcher.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isTableLine } from "../src/editor/tableLineMatcher.ts";
+
+test("isTableLine matches GFM separator rows", () => {
+  assert.equal(isTableLine("|---|---|"), true);
+  assert.equal(isTableLine("| --- | --- |"), true);
+  assert.equal(isTableLine("|:--|--:|:--:|"), true);
+  assert.equal(isTableLine("---|---"), true);
+});
+
+test("isTableLine matches piped data rows", () => {
+  assert.equal(isTableLine("| foo | bar |"), true);
+  assert.equal(isTableLine("|a|b|"), true);
+});
+
+test("isTableLine rejects empty lines and non-pipe content", () => {
+  assert.equal(isTableLine(""), false);
+  assert.equal(isTableLine("   "), false);
+  assert.equal(isTableLine("plain text"), false);
+});
+
+test("isTableLine rejects bare pipe text without leading/trailing pipes", () => {
+  assert.equal(isTableLine("foo | bar"), false);
+});

--- a/apps/webview-demo/tests/themeController.test.ts
+++ b/apps/webview-demo/tests/themeController.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createThemeController } from "../src/ui/themeController.ts";
+
+type Listener = (event: unknown) => void;
+
+function makeButton(): HTMLButtonElement {
+  const attrs = new Map<string, string>();
+  const listeners = new Map<string, Listener[]>();
+  const button = {
+    setAttribute(name: string, value: string) {
+      attrs.set(name, value);
+    },
+    getAttribute(name: string) {
+      return attrs.get(name) ?? null;
+    },
+    addEventListener(type: string, listener: Listener) {
+      const arr = listeners.get(type) ?? [];
+      arr.push(listener);
+      listeners.set(type, arr);
+    },
+    dispatchClick() {
+      for (const l of listeners.get("click") ?? []) {
+        l({});
+      }
+    },
+  } as unknown as HTMLButtonElement & { dispatchClick: () => void };
+  return button;
+}
+
+function makeRoot(): HTMLElement {
+  const dataset: Record<string, string> = {};
+  return { dataset } as unknown as HTMLElement;
+}
+
+test("createThemeController initializes from prefersDarkMatcher", () => {
+  const toggle = makeButton();
+  const root = makeRoot();
+  createThemeController({
+    toggle,
+    root,
+    prefersDarkMatcher: () => true,
+  });
+  assert.equal(root.dataset.theme, "dark");
+  assert.equal(toggle.getAttribute("aria-pressed"), "true");
+});
+
+test("createThemeController defaults to light when prefersDarkMatcher is false", () => {
+  const toggle = makeButton();
+  const root = makeRoot();
+  createThemeController({
+    toggle,
+    root,
+    prefersDarkMatcher: () => false,
+  });
+  assert.equal(root.dataset.theme, "light");
+  assert.equal(toggle.getAttribute("aria-pressed"), "false");
+});
+
+test("toggle click flips data-theme and aria-pressed", () => {
+  const toggle = makeButton() as HTMLButtonElement & { dispatchClick: () => void };
+  const root = makeRoot();
+  createThemeController({
+    toggle,
+    root,
+    prefersDarkMatcher: () => false,
+  });
+  toggle.dispatchClick();
+  assert.equal(root.dataset.theme, "dark");
+  assert.equal(toggle.getAttribute("aria-pressed"), "true");
+  toggle.dispatchClick();
+  assert.equal(root.dataset.theme, "light");
+  assert.equal(toggle.getAttribute("aria-pressed"), "false");
+});

--- a/apps/webview-demo/tsconfig.json
+++ b/apps/webview-demo/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "noEmit": true,
     "types": ["vite/client"],
     "baseUrl": ".",


### PR DESCRIPTION
## Summary

webview-demo の `createEditor.ts` (119行) と `app.ts` (232行) に詰まっていた以下の責務を独立モジュールに分割し、`setupApp` を配線のみ (約60行) に縮退しました。

- **editor/linkClickHandler.ts**: `.mb-link[data-href]` のクリック処理。`resolveLinkClickIntent` 純粋関数 + Extension factory に分離
- **editor/baseExtensions.ts**: history / smartBol / keymap / markdown / updateListener / linkClick の集約
- **editor/extensionBuilders.ts**: 機能別の純粋 builder 関数 (diffGutter / lineNumbers / wrap / tabSize / theme / livePreview)
- **editor/buildExtensions.ts**: ExtensionOptions から拡張一覧を組み立てる
- **editor/tableLineMatcher.ts**: `isTableLine`
- **ui/controls.ts**: DOM 取得と型ガード一元化
- **ui/themeController.ts**: prefers-color-scheme 連動 + data-theme/aria-pressed 同期
- **ui/settingsMenuController.ts**: open/close + Escape + 外側 pointerdown + destroy

## テスト追加

各モジュールに単体テストを追加 (linkClick / tableLine / extensionBuilders / theme / settings、計 +16 ケース)。
Node の test runner で `.ts` 拡張子付き import を解決するため `tsconfig.json` に `allowImportingTsExtensions: true` を追加。

## 注意点

- 現状の `apps/mac/src/app.ts` にも同じ `isTableLine` が重複しているが、本 PR は webview-demo に閉じる方針 (#130 系列の別 issue で対応検討)
- `instanceof Node` を `typeof Node !== "undefined"` ガード付きに変更 (Node 環境のテスト容易化、ブラウザ動作は等価)
- リンククリックの `preventDefault` / `stopPropagation` は旧実装と同じく href がアンカー (`#xxx`) または外部の時点で発火 (Codex レビューで回帰指摘 → 修正済み)

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:core`
- [x] `pnpm -C apps/webview-demo test:unit` (32 件成功)
- [x] `pnpm -C apps/webview-demo build`
- [x] pm2 起動 + Playwright 動作確認: ページ表示・heading anchor ジャンプ・テーマトグル・設定メニュー open/close (Apply / Escape / 外側クリック)・smart-bol 全項目 PASS
- [x] Codex レビュー実施・指摘修正済み (`#missing` アンカー時の preventDefault 回帰を修正)

Refs #130
Closes #132

> Note: ベースを `refactor/130-1-dedupe-create-editor` (PR #135) にしています。#135 マージ後にこの PR のベースを `main` に張り替えてください。