### PR TITLE
refactor: cm6-table の足場を整理して TableWidget 分割の準備を進める (#134)

### DIFF
--- a/packages/core/cm6-table/src/index.ts
+++ b/packages/core/cm6-table/src/index.ts
@@ -1,12 +1,10 @@
 import { syntaxTree } from "@codemirror/language";
 import {
-  Annotation,
   Prec,
   RangeSetBuilder,
   StateField,
   type EditorState,
   type Extension,
-  type TransactionSpec,
 } from "@codemirror/state";
 import {
   Decoration,
@@ -15,7 +13,12 @@ import {
   WidgetType,
   keymap,
 } from "@codemirror/view";
-import type { TableAlignment, TableData } from "./types";
+import type {
+  TableAlignment,
+  TableData,
+  TableEditorOptions,
+  TableInfo,
+} from "./types";
 import {
   cloneTableData,
   deleteColumnAt,
@@ -51,23 +54,14 @@ import {
   isLikelyTableBoundaryCandidateLine,
   type TableBoundaryInfo,
 } from "./tableDetection";
+import { dispatchOutsideSelection, dispatchOutsideUpdate } from "./tableDispatch";
+import {
+  defaultTableEditorOptions,
+  focusCellRequestEvent,
+  tableEditAnnotation,
+} from "./tableEditorConstants";
 
-export type { TableAlignment, TableData };
-
-export type TableEditorOptions = {
-  enabled?: boolean;
-  renderMode?: "widget" | "none";
-};
-
-type TableInfo = {
-  key: string;
-  from: number;
-  to: number;
-  startLineFrom: number;
-  endLineTo: number;
-  startLineNumber: number;
-  endLineNumber: number;
-};
+export type { TableAlignment, TableData, TableEditorOptions };
 
 type CellSelection = {
   kind: "cell";
@@ -113,12 +107,6 @@ type FocusCellRequest = {
   col: number;
 };
 
-const tableEditAnnotation = Annotation.define<boolean>();
-const focusCellRequestEvent = "cm6-table-focus-cell-request";
-const defaultOptions: Required<TableEditorOptions> = {
-  enabled: true,
-  renderMode: "widget",
-};
 
 function tableDataSignature(data: TableData): string {
   const cols = getColumnCount(data);
@@ -1811,43 +1799,6 @@ class TableWidget extends WidgetType {
   }
 }
 
-function dispatchOutsideUpdate(
-  view: EditorView,
-  transaction: {
-    changes: { from: number; to: number; insert: string };
-    annotations: Annotation<unknown>;
-  }
-) {
-  dispatchOutsideTransaction(view, transaction);
-}
-
-function dispatchOutsideSelection(view: EditorView, anchor: number, focusEditor = false) {
-  if (focusEditor) {
-    view.focus();
-  }
-  view.dispatch({
-    selection: { anchor },
-    scrollIntoView: true,
-  });
-}
-
-function dispatchOutsideTransaction(
-  view: EditorView,
-  transaction: TransactionSpec,
-  focusEditor = false
-) {
-  const scrollTop = view.scrollDOM.scrollTop;
-  const scrollLeft = view.scrollDOM.scrollLeft;
-  view.dispatch({ ...transaction, scrollIntoView: false });
-  if (focusEditor) {
-    view.focus();
-  }
-  requestAnimationFrame(() => {
-    view.scrollDOM.scrollTop = scrollTop;
-    view.scrollDOM.scrollLeft = scrollLeft;
-  });
-}
-
 function buildDecorations(
   state: EditorState,
   options: Required<TableEditorOptions>
@@ -1898,7 +1849,7 @@ function buildDecorations(
 }
 
 export function tableEditor(options: TableEditorOptions = {}): Extension {
-  const resolved = { ...defaultOptions, ...options };
+  const resolved = { ...defaultTableEditorOptions, ...options };
 
   const theme = EditorView.baseTheme({
     ".cm-content .cm6-table-editor": {

--- a/packages/core/cm6-table/src/tableDispatch.ts
+++ b/packages/core/cm6-table/src/tableDispatch.ts
@@ -1,0 +1,48 @@
+import type { Annotation, TransactionSpec } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+
+// TableWidget が編集をエディタへ反映するときに利用する dispatch ヘルパー群。
+// いずれも widget からの操作で発生する余分な再スクロールを抑えつつ
+// (scroll 位置を保存→dispatch→次のフレームで復元)、必要に応じて
+// エディタにフォーカスを戻す。
+
+export function dispatchOutsideTransaction(
+  view: EditorView,
+  transaction: TransactionSpec,
+  focusEditor = false
+): void {
+  const scrollTop = view.scrollDOM.scrollTop;
+  const scrollLeft = view.scrollDOM.scrollLeft;
+  view.dispatch({ ...transaction, scrollIntoView: false });
+  if (focusEditor) {
+    view.focus();
+  }
+  requestAnimationFrame(() => {
+    view.scrollDOM.scrollTop = scrollTop;
+    view.scrollDOM.scrollLeft = scrollLeft;
+  });
+}
+
+export function dispatchOutsideUpdate(
+  view: EditorView,
+  transaction: {
+    changes: { from: number; to: number; insert: string };
+    annotations: Annotation<unknown>;
+  }
+): void {
+  dispatchOutsideTransaction(view, transaction);
+}
+
+export function dispatchOutsideSelection(
+  view: EditorView,
+  anchor: number,
+  focusEditor = false
+): void {
+  if (focusEditor) {
+    view.focus();
+  }
+  view.dispatch({
+    selection: { anchor },
+    scrollIntoView: true,
+  });
+}

--- a/packages/core/cm6-table/src/tableEditorConstants.ts
+++ b/packages/core/cm6-table/src/tableEditorConstants.ts
@@ -1,0 +1,14 @@
+import { Annotation } from "@codemirror/state";
+import type { TableEditorOptions } from "./types";
+
+// テーブル編集起因の dispatch を判別するためのアノテーション。
+// 同じ doc 変更でも widget 由来かどうかを StateField 側で見分けるのに使う。
+export const tableEditAnnotation = Annotation.define<boolean>();
+
+// TableWidget からエディタへ「特定セルにフォーカスを戻したい」依頼を伝える DOM イベント名。
+export const focusCellRequestEvent = "cm6-table-focus-cell-request";
+
+export const defaultTableEditorOptions: Required<TableEditorOptions> = {
+  enabled: true,
+  renderMode: "widget",
+};

--- a/packages/core/cm6-table/src/types.ts
+++ b/packages/core/cm6-table/src/types.ts
@@ -15,3 +15,18 @@ export type TableData = {
   rows: TableRow[];
   alignments: TableAlignment[];
 };
+
+export type TableEditorOptions = {
+  enabled?: boolean;
+  renderMode?: "widget" | "none";
+};
+
+export type TableInfo = {
+  key: string;
+  from: number;
+  to: number;
+  startLineFrom: number;
+  endLineTo: number;
+  startLineNumber: number;
+  endLineNumber: number;
+};

--- a/packages/core/cm6-table/tests/tableDispatch.test.ts
+++ b/packages/core/cm6-table/tests/tableDispatch.test.ts
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Annotation } from "@codemirror/state";
+import {
+  dispatchOutsideSelection,
+  dispatchOutsideTransaction,
+  dispatchOutsideUpdate,
+} from "../src/tableDispatch";
+
+type DispatchedSpec = {
+  scrollIntoView?: boolean;
+  selection?: { anchor: number };
+  changes?: { from: number; to: number; insert: string };
+  annotations?: Annotation<unknown>;
+};
+
+function makeMockView(
+  initialScroll = { top: 17, left: 23 },
+  options: { scrollMutationOnDispatch?: { top: number; left: number } } = {}
+) {
+  const dispatched: DispatchedSpec[] = [];
+  let focusCount = 0;
+  let raf: (() => void) | null = null;
+  const view = {
+    scrollDOM: { scrollTop: initialScroll.top, scrollLeft: initialScroll.left },
+    dispatch(spec: DispatchedSpec) {
+      dispatched.push(spec);
+      // 実際の EditorView.dispatch は内部で scrollIntoView 等により scrollDOM を
+      // 動かしうる。テストではこのケースを再現するため、明示的に scroll を変動
+      // させて RAF 内の復元が効いていることを検出できるようにする。
+      if (options.scrollMutationOnDispatch) {
+        view.scrollDOM.scrollTop = options.scrollMutationOnDispatch.top;
+        view.scrollDOM.scrollLeft = options.scrollMutationOnDispatch.left;
+      }
+    },
+    focus() {
+      focusCount += 1;
+    },
+  };
+  // requestAnimationFrame は capture して同期的に呼べるようにする
+  const originalRaf = globalThis.requestAnimationFrame;
+  (globalThis as unknown as { requestAnimationFrame: (cb: () => void) => number }).requestAnimationFrame = (cb) => {
+    raf = cb;
+    return 0;
+  };
+  return {
+    view,
+    dispatched,
+    getFocusCount: () => focusCount,
+    flushRaf: () => {
+      raf?.();
+      raf = null;
+    },
+    restore: () => {
+      globalThis.requestAnimationFrame = originalRaf;
+    },
+  };
+}
+
+test("dispatchOutsideTransaction disables scrollIntoView and restores scroll position via raf", () => {
+  // dispatch 中に内部で scroll が動いた状況を再現し、raf 後に元位置に戻ることを検出する。
+  const ctx = makeMockView(
+    { top: 100, left: 50 },
+    { scrollMutationOnDispatch: { top: 999, left: 888 } }
+  );
+  try {
+    const annotations = Annotation.define<boolean>().of(true);
+    dispatchOutsideTransaction(
+      ctx.view as unknown as Parameters<typeof dispatchOutsideTransaction>[0],
+      {
+        changes: { from: 0, to: 0, insert: "x" },
+        annotations,
+      }
+    );
+    assert.equal(ctx.dispatched.length, 1);
+    assert.equal(ctx.dispatched[0].scrollIntoView, false);
+    // dispatch 直後: mock 内で scroll が変動した状態
+    assert.equal(ctx.view.scrollDOM.scrollTop, 999);
+    assert.equal(ctx.view.scrollDOM.scrollLeft, 888);
+    // raf 後: 元の scroll 位置に復元される
+    ctx.flushRaf();
+    assert.equal(ctx.view.scrollDOM.scrollTop, 100);
+    assert.equal(ctx.view.scrollDOM.scrollLeft, 50);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("dispatchOutsideTransaction focuses editor when focusEditor is true", () => {
+  const ctx = makeMockView();
+  try {
+    dispatchOutsideTransaction(
+      ctx.view as unknown as Parameters<typeof dispatchOutsideTransaction>[0],
+      { selection: { anchor: 0 } },
+      true
+    );
+    assert.equal(ctx.getFocusCount(), 1);
+    ctx.flushRaf();
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("dispatchOutsideUpdate routes through dispatchOutsideTransaction", () => {
+  const ctx = makeMockView();
+  try {
+    const annotations = Annotation.define<boolean>().of(true);
+    dispatchOutsideUpdate(
+      ctx.view as unknown as Parameters<typeof dispatchOutsideUpdate>[0],
+      { changes: { from: 0, to: 0, insert: "y" }, annotations }
+    );
+    assert.equal(ctx.dispatched.length, 1);
+    assert.equal(ctx.dispatched[0].changes?.insert, "y");
+    assert.equal(ctx.dispatched[0].scrollIntoView, false);
+    ctx.flushRaf();
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("dispatchOutsideSelection dispatches selection with scrollIntoView true", () => {
+  const ctx = makeMockView();
+  try {
+    dispatchOutsideSelection(
+      ctx.view as unknown as Parameters<typeof dispatchOutsideSelection>[0],
+      42
+    );
+    assert.equal(ctx.dispatched.length, 1);
+    assert.deepEqual(ctx.dispatched[0].selection, { anchor: 42 });
+    assert.equal(ctx.dispatched[0].scrollIntoView, true);
+    assert.equal(ctx.getFocusCount(), 0);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("dispatchOutsideSelection focuses editor when requested", () => {
+  const ctx = makeMockView();
+  try {
+    dispatchOutsideSelection(
+      ctx.view as unknown as Parameters<typeof dispatchOutsideSelection>[0],
+      7,
+      true
+    );
+    assert.equal(ctx.getFocusCount(), 1);
+  } finally {
+    ctx.restore();
+  }
+});


### PR DESCRIPTION
## Summary

#134 (cm6-table 構造整理) の **第一段階**。`TableWidget` クラス本体 (1667 行) は今回触らず、まわりの共有定数・dispatch ヘルパー・型を sub-file に切り出して `index.ts` を整理しました。

- `src/tableDispatch.ts` (新規): `dispatchOutsideUpdate` / `dispatchOutsideSelection` / `dispatchOutsideTransaction` を切り出し
- `src/tableEditorConstants.ts` (新規): `tableEditAnnotation` / `focusCellRequestEvent` / `defaultTableEditorOptions` を切り出し
- `src/types.ts`: `TableEditorOptions` / `TableInfo` 型を追加
- `src/index.ts`: 上記の定義を削除し import に切り替え。`defaultOptions` → `defaultTableEditorOptions` に rename
- `tests/tableDispatch.test.ts` (新規): dispatch ヘルパーの単体テスト 5 ケース (raf 内の scroll 復元を mock の scroll 変動で検出する形)

`tableDataSignature` と `toCssTextAlign` は ASCII 制御文字 (US/RS/GS) リテラルを含み、また TableWidget 内部からのみ参照されるため index.ts に残しました。

## TableWidget 本体の分割について

TableWidget の context menu / drag-drop / cell ops 等は this 参照が多く、一気に分割すると diff が膨大かつ回帰リスクが高いので、本 PR には含めません。次の PR で段階的に対応します。

## 動作確認

- `pnpm typecheck` / `pnpm lint`
- `pnpm -C packages/core/cm6-table test` (60 件成功、+5 件)
- `pnpm test:core`
- `pnpm -C apps/webview-demo build`
- playwright-cli で webview-demo の sample 内テーブル widget レンダリング確認・キーボードナビゲーション (ArrowDown でセル移動) 動作確認・console error 0 件
- Codex レビュー実施 → 指摘 (テスト検出力強化、ファイル名 `tableEditorState` → `tableEditorConstants`) を反映済み

Refs #130
Closes #134

> Note: ベースを #137 (`refactor/130-3-tidy-theme-layer`) にしています。順次マージで `main` へ向けてください。