### PR TITLE
refactor: cm6-table の TableWidget から純粋関数を切り出し (#139)

### DIFF
--- a/packages/core/cm6-table/src/index.ts
+++ b/packages/core/cm6-table/src/index.ts
@@ -33,7 +33,6 @@ import {
 } from "./tableModel";
 import {
   buildTableCommitChange,
-  clampCellSelection,
   getTableCellText,
   setTableCellText,
 } from "./tableEditing";
@@ -60,6 +59,16 @@ import {
   focusCellRequestEvent,
   tableEditAnnotation,
 } from "./tableEditorConstants";
+import {
+  clampCell as clampCellPure,
+  defaultCellSelection as defaultCellSelectionPure,
+  moveCellByOffset as moveCellByOffsetPure,
+} from "./tableCellSelection";
+import { createDragIndicatorIcon } from "./tableHandleIcon";
+import {
+  remapSelectionForColReorder as remapSelectionForColReorderPure,
+  remapSelectionForRowReorder as remapSelectionForRowReorderPure,
+} from "./tableReorder";
 
 export type { TableAlignment, TableData, TableEditorOptions };
 
@@ -161,23 +170,6 @@ class TableWidget extends WidgetType {
     return next;
   }
 
-  private static createDragIndicatorIcon(): SVGElement {
-    const ns = "http://www.w3.org/2000/svg";
-    const svg = document.createElementNS(ns, "svg");
-    svg.setAttribute("viewBox", "0 0 24 24");
-    svg.setAttribute("aria-hidden", "true");
-    svg.classList.add("cm-table-handle-icon");
-
-    const path = document.createElementNS(ns, "path");
-    path.setAttribute(
-      "d",
-      "M11 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm8 16c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-    );
-
-    svg.appendChild(path);
-    return svg;
-  }
-
   constructor(private readonly data: TableData, private readonly tableInfo: TableInfo) {
     super();
     this.signature = tableDataSignature(data);
@@ -268,15 +260,10 @@ class TableWidget extends WidgetType {
       TableWidget.bumpFocusRestoreGeneration(view);
     };
 
-    const clampCell = (nextRow: number, nextCol: number): CellSelection => {
-      return {
-        kind: "cell",
-        ...clampCellSelection(nextRow, nextCol, getTotalRows(), columnCount),
-      };
-    };
-    const defaultCellSelection = (): CellSelection => {
-      return clampCell(data.rows.length > 0 ? 1 : 0, 0);
-    };
+    const clampCell = (nextRow: number, nextCol: number): CellSelection =>
+      clampCellPure(nextRow, nextCol, getTotalRows(), columnCount);
+    const defaultCellSelection = (): CellSelection =>
+      defaultCellSelectionPure(data.rows.length, getTotalRows(), columnCount);
 
     const getCellText = (cell: CellSelection): string => getTableCellText(data, cell);
 
@@ -538,105 +525,29 @@ class TableWidget extends WidgetType {
       colDropMarker = { colIndex, side };
     };
 
-    const remapRowIndex = (
-      sourceIndex: number,
-      targetInsertIndex: number,
-      index: number
-    ): number => {
-      const clampedSource = Math.max(0, Math.min(sourceIndex, data.rows.length - 1));
-      const clampedIndex = Math.max(0, Math.min(index, data.rows.length - 1));
-      let finalInsert = Math.max(0, Math.min(targetInsertIndex, data.rows.length));
-      if (clampedSource < finalInsert) {
-        finalInsert -= 1;
-      }
-      if (clampedIndex === clampedSource) {
-        return finalInsert;
-      }
-      if (clampedSource < finalInsert) {
-        return clampedIndex > clampedSource && clampedIndex <= finalInsert
-          ? clampedIndex - 1
-          : clampedIndex;
-      }
-      return clampedIndex >= finalInsert && clampedIndex < clampedSource
-        ? clampedIndex + 1
-        : clampedIndex;
-    };
-
     const remapSelectionForRowReorder = (
       current: SelectionState | null,
       sourceIndex: number,
       targetInsertIndex: number
-    ): SelectionState | null => {
-      if (!current) {
-        return null;
-      }
-      if (current.kind === "row") {
-        return {
-          kind: "row",
-          row: remapRowIndex(sourceIndex, targetInsertIndex, current.row),
-        };
-      }
-      if (current.kind === "cell") {
-        if (current.row === 0) {
-          return current;
-        }
-        const bodyRowIndex = current.row - 1;
-        return {
-          kind: "cell",
-          row: remapRowIndex(sourceIndex, targetInsertIndex, bodyRowIndex) + 1,
-          col: current.col,
-        };
-      }
-      return current;
-    };
-
-    const remapColIndex = (
-      sourceIndex: number,
-      targetInsertIndex: number,
-      index: number
-    ): number => {
-      const clampedSource = Math.max(0, Math.min(sourceIndex, columnCount - 1));
-      const clampedIndex = Math.max(0, Math.min(index, columnCount - 1));
-      let finalInsert = Math.max(0, Math.min(targetInsertIndex, columnCount));
-      if (clampedSource < finalInsert) {
-        finalInsert -= 1;
-      }
-      if (clampedIndex === clampedSource) {
-        return finalInsert;
-      }
-      if (clampedSource < finalInsert) {
-        return clampedIndex > clampedSource && clampedIndex <= finalInsert
-          ? clampedIndex - 1
-          : clampedIndex;
-      }
-      return clampedIndex >= finalInsert && clampedIndex < clampedSource
-        ? clampedIndex + 1
-        : clampedIndex;
-    };
+    ): SelectionState | null =>
+      remapSelectionForRowReorderPure(
+        current,
+        sourceIndex,
+        targetInsertIndex,
+        data.rows.length
+      );
 
     const remapSelectionForColReorder = (
       current: SelectionState | null,
       sourceIndex: number,
       targetInsertIndex: number
-    ): SelectionState | null => {
-      if (!current) {
-        return null;
-      }
-      if (current.kind === "column") {
-        return {
-          kind: "column",
-          col: remapColIndex(sourceIndex, targetInsertIndex, current.col),
-        };
-      }
-      if (current.kind === "cell") {
-        return {
-          kind: "cell",
-          row: current.row,
-          col: remapColIndex(sourceIndex, targetInsertIndex, current.col),
-        };
-      }
-      return current;
-    };
+    ): SelectionState | null =>
+      remapSelectionForColReorderPure(
+        current,
+        sourceIndex,
+        targetInsertIndex,
+        columnCount
+      );
 
     const commitRowDrop = (sourceIndex: number, marker: RowDropMarker) => {
       if (!marker) {
@@ -1148,7 +1059,7 @@ class TableWidget extends WidgetType {
       handle.dataset.colIndex = String(col);
       handle.tabIndex = -1;
       handle.setAttribute("aria-label", `Select column ${col + 1}`);
-      const icon = TableWidget.createDragIndicatorIcon();
+      const icon = createDragIndicatorIcon();
       icon.classList.add("cm-table-col-handle-icon");
       handle.appendChild(icon);
       handle.addEventListener(
@@ -1252,7 +1163,7 @@ class TableWidget extends WidgetType {
       handle.style.color = rowHandleBaseColor;
       handle.tabIndex = -1;
       handle.setAttribute("aria-label", `Select row ${rowIndex + 1}`);
-      const icon = TableWidget.createDragIndicatorIcon();
+      const icon = createDragIndicatorIcon();
       icon.classList.add("cm-table-row-handle-icon");
       handle.appendChild(icon);
       handle.addEventListener(
@@ -1336,14 +1247,8 @@ class TableWidget extends WidgetType {
       rowHandleButtons[rowIndex] = handle;
     });
 
-    const moveCellByOffset = (current: CellSelection, delta: number): CellSelection => {
-      const totalCells = getTotalRows() * columnCount;
-      const flat = current.row * columnCount + current.col;
-      const nextFlat = (flat + delta + totalCells) % totalCells;
-      const nextRow = Math.floor(nextFlat / columnCount);
-      const nextCol = nextFlat % columnCount;
-      return { kind: "cell", row: nextRow, col: nextCol };
-    };
+    const moveCellByOffset = (current: CellSelection, delta: number): CellSelection =>
+      moveCellByOffsetPure(current, delta, getTotalRows(), columnCount);
 
     const moveSelectionOutsideTable = (lineNumber: number): boolean => {
       if (lineNumber < 1 || lineNumber > view.state.doc.lines) {

--- a/packages/core/cm6-table/src/tableCellSelection.ts
+++ b/packages/core/cm6-table/src/tableCellSelection.ts
@@ -1,0 +1,51 @@
+import { clampCellSelection } from "./tableEditing";
+
+// TableWidget 内部の selection 型と同一構造。
+// (#134 phase 3 で SelectionState 全体を別ファイルに移すまで、ここで cell 選択のみ
+//  ローカル型として持っておく。RowSelection / ColumnSelection は本ファイルでは扱わない)
+export type TableCellSelection = {
+  kind: "cell";
+  row: number;
+  col: number;
+};
+
+// 行・列のサイズに収まるよう座標をクランプし、CellSelection を返す。
+export function clampCell(
+  nextRow: number,
+  nextCol: number,
+  totalRows: number,
+  columnCount: number
+): TableCellSelection {
+  return {
+    kind: "cell",
+    ...clampCellSelection(nextRow, nextCol, totalRows, columnCount),
+  };
+}
+
+// テーブルが空でない場合は最初の body 行 (row=1)、空なら header 行 (row=0) を選択する。
+export function defaultCellSelection(
+  bodyRowCount: number,
+  totalRows: number,
+  columnCount: number
+): TableCellSelection {
+  return clampCell(bodyRowCount > 0 ? 1 : 0, 0, totalRows, columnCount);
+}
+
+// 平坦化 (row * columnCount + col) されたインデックスで delta セル分移動する。
+// オフセット計算は totalRows * columnCount でラップする。
+export function moveCellByOffset(
+  current: TableCellSelection,
+  delta: number,
+  totalRows: number,
+  columnCount: number
+): TableCellSelection {
+  const totalCells = totalRows * columnCount;
+  if (totalCells === 0) {
+    return current;
+  }
+  const flat = current.row * columnCount + current.col;
+  const nextFlat = (((flat + delta) % totalCells) + totalCells) % totalCells;
+  const nextRow = Math.floor(nextFlat / columnCount);
+  const nextCol = nextFlat % columnCount;
+  return { kind: "cell", row: nextRow, col: nextCol };
+}

--- a/packages/core/cm6-table/src/tableHandleIcon.ts
+++ b/packages/core/cm6-table/src/tableHandleIcon.ts
@@ -1,0 +1,18 @@
+// テーブルの行・列ハンドルに使うドラッグインジケータの SVG アイコンを生成する。
+// 6 ドット (3 行 x 2 列) のレイアウト。
+export function createDragIndicatorIcon(): SVGElement {
+  const ns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(ns, "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("aria-hidden", "true");
+  svg.classList.add("cm-table-handle-icon");
+
+  const path = document.createElementNS(ns, "path");
+  path.setAttribute(
+    "d",
+    "M11 18c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm8 16c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+  );
+
+  svg.appendChild(path);
+  return svg;
+}

--- a/packages/core/cm6-table/src/tableReorder.ts
+++ b/packages/core/cm6-table/src/tableReorder.ts
@@ -1,0 +1,110 @@
+// 行・列を並べ替えたとき、selection を新しい位置に追従させる純粋ロジック。
+// TableWidget の toDOM 内クロージャから切り出した。
+//
+// `sourceIndex`: 動かしたい行/列の元のインデックス
+// `targetInsertIndex`: 挿入したい位置 (元の配列での「この位置の前」を指す)
+// `index`: 追従計算したい既存の選択座標
+
+// reorder 後のインデックスを再計算する。範囲外は最も近い有効インデックスへクランプ。
+export function remapReorderIndex(
+  sourceIndex: number,
+  targetInsertIndex: number,
+  index: number,
+  totalCount: number
+): number {
+  if (totalCount <= 0) {
+    return 0;
+  }
+  const clampedSource = Math.max(0, Math.min(sourceIndex, totalCount - 1));
+  const clampedIndex = Math.max(0, Math.min(index, totalCount - 1));
+  let finalInsert = Math.max(0, Math.min(targetInsertIndex, totalCount));
+  if (clampedSource < finalInsert) {
+    finalInsert -= 1;
+  }
+  if (clampedIndex === clampedSource) {
+    return finalInsert;
+  }
+  if (clampedSource < finalInsert) {
+    return clampedIndex > clampedSource && clampedIndex <= finalInsert
+      ? clampedIndex - 1
+      : clampedIndex;
+  }
+  return clampedIndex >= finalInsert && clampedIndex < clampedSource
+    ? clampedIndex + 1
+    : clampedIndex;
+}
+
+import type { TableCellSelection } from "./tableCellSelection";
+
+// SelectionState (内部型) と同一構造の最小定義。
+// CellSelection は tableCellSelection.ts と共有することで型の乖離を防ぐ。
+// RowSelection / ColumnSelection は #134 phase 3 で selection 全体を別ファイルに
+// 移すまで本ファイル内ローカル型で保持する。
+type CellSelection = TableCellSelection;
+type RowSelection = { kind: "row"; row: number };
+type ColumnSelection = { kind: "column"; col: number };
+type SelectionState = CellSelection | RowSelection | ColumnSelection;
+
+// 行 reorder に対して selection を追従。
+// - row selection: そのまま remap
+// - cell selection: header 行 (row=0) は変えず、body 行は body index (row-1) で remap して +1
+// - column selection: 列 reorder の影響を受けないのでそのまま
+export function remapSelectionForRowReorder(
+  current: SelectionState | null,
+  sourceIndex: number,
+  targetInsertIndex: number,
+  bodyRowCount: number
+): SelectionState | null {
+  if (!current) {
+    return null;
+  }
+  if (current.kind === "row") {
+    return {
+      kind: "row",
+      row: remapReorderIndex(sourceIndex, targetInsertIndex, current.row, bodyRowCount),
+    };
+  }
+  if (current.kind === "cell") {
+    if (current.row === 0) {
+      return current;
+    }
+    const bodyRowIndex = current.row - 1;
+    return {
+      kind: "cell",
+      row:
+        remapReorderIndex(sourceIndex, targetInsertIndex, bodyRowIndex, bodyRowCount) +
+        1,
+      col: current.col,
+    };
+  }
+  return current;
+}
+
+// 列 reorder に対して selection を追従。
+// - column selection: remap
+// - cell selection: row はそのまま、col のみ remap
+// - row selection: 行 reorder の影響を受けないのでそのまま
+export function remapSelectionForColReorder(
+  current: SelectionState | null,
+  sourceIndex: number,
+  targetInsertIndex: number,
+  columnCount: number
+): SelectionState | null {
+  if (!current) {
+    return null;
+  }
+  if (current.kind === "column") {
+    return {
+      kind: "column",
+      col: remapReorderIndex(sourceIndex, targetInsertIndex, current.col, columnCount),
+    };
+  }
+  if (current.kind === "cell") {
+    return {
+      kind: "cell",
+      row: current.row,
+      col: remapReorderIndex(sourceIndex, targetInsertIndex, current.col, columnCount),
+    };
+  }
+  return current;
+}

--- a/packages/core/cm6-table/tests/tableCellSelection.test.ts
+++ b/packages/core/cm6-table/tests/tableCellSelection.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  clampCell,
+  defaultCellSelection,
+  moveCellByOffset,
+} from "../src/tableCellSelection";
+
+test("clampCell keeps in-range coordinates", () => {
+  assert.deepEqual(clampCell(1, 2, 4, 4), { kind: "cell", row: 1, col: 2 });
+});
+
+test("clampCell clamps negative and overshoot to nearest valid bounds", () => {
+  assert.deepEqual(clampCell(-3, -1, 4, 4), { kind: "cell", row: 0, col: 0 });
+  assert.deepEqual(clampCell(99, 99, 3, 2), { kind: "cell", row: 2, col: 1 });
+});
+
+test("defaultCellSelection prefers first body row when rows exist", () => {
+  // bodyRowCount=2, totalRows=3 (header + 2 body), columnCount=2
+  assert.deepEqual(defaultCellSelection(2, 3, 2), { kind: "cell", row: 1, col: 0 });
+});
+
+test("defaultCellSelection falls back to header row when no body rows exist", () => {
+  // body=0, totalRows=1 (only header), columnCount=3
+  assert.deepEqual(defaultCellSelection(0, 1, 3), { kind: "cell", row: 0, col: 0 });
+});
+
+test("moveCellByOffset advances within row and wraps to next row", () => {
+  // 2 rows x 3 cols
+  const start = { kind: "cell" as const, row: 0, col: 1 };
+  assert.deepEqual(moveCellByOffset(start, 1, 2, 3), { kind: "cell", row: 0, col: 2 });
+  assert.deepEqual(moveCellByOffset(start, 2, 2, 3), { kind: "cell", row: 1, col: 0 });
+});
+
+test("moveCellByOffset wraps around past the end and from the start", () => {
+  const last = { kind: "cell" as const, row: 1, col: 2 };
+  assert.deepEqual(moveCellByOffset(last, 1, 2, 3), { kind: "cell", row: 0, col: 0 });
+  const first = { kind: "cell" as const, row: 0, col: 0 };
+  assert.deepEqual(moveCellByOffset(first, -1, 2, 3), { kind: "cell", row: 1, col: 2 });
+});
+
+test("moveCellByOffset handles delta larger than total cells (fixes negative-modulo bug from old closure impl)", () => {
+  // 旧実装は (flat + delta + totalCells) % totalCells で、delta < -totalCells で
+  // 負の余りが残り row/col が負になる挙動だった。新実装は (((x % m) + m) % m) で安全。
+  // total=6 cells; delta=7 should land 1 step forward from start
+  const start = { kind: "cell" as const, row: 0, col: 0 };
+  assert.deepEqual(moveCellByOffset(start, 7, 2, 3), { kind: "cell", row: 0, col: 1 });
+  assert.deepEqual(moveCellByOffset(start, -7, 2, 3), { kind: "cell", row: 1, col: 2 });
+});
+
+test("moveCellByOffset returns current selection when grid is empty", () => {
+  const cur = { kind: "cell" as const, row: 0, col: 0 };
+  assert.deepEqual(moveCellByOffset(cur, 1, 0, 0), cur);
+});

--- a/packages/core/cm6-table/tests/tableReorder.test.ts
+++ b/packages/core/cm6-table/tests/tableReorder.test.ts
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  remapReorderIndex,
+  remapSelectionForColReorder,
+  remapSelectionForRowReorder,
+} from "../src/tableReorder";
+
+test("remapReorderIndex returns insert position for the moved index itself", () => {
+  // 5 行を仮定し、index=1 を index=4 (4 つ目の前) に移動。
+  // remap した後の自身の位置は 3 (targetInsertIndex=4 を超えていれば -1 補正)
+  assert.equal(remapReorderIndex(1, 4, 1, 5), 3);
+});
+
+test("remapReorderIndex shifts indices between moved and target", () => {
+  // 5 行で source=1 を target=4 に動かす場合、index=2 と 3 はそれぞれ 1 と 2 に詰まる
+  assert.equal(remapReorderIndex(1, 4, 2, 5), 1);
+  assert.equal(remapReorderIndex(1, 4, 3, 5), 2);
+  // 範囲外 (target を超えた行) はそのまま
+  assert.equal(remapReorderIndex(1, 4, 4, 5), 4);
+});
+
+test("remapReorderIndex handles backward moves", () => {
+  // source=4 を target=1 に動かす。index=2 / 3 は +1 シフト。
+  assert.equal(remapReorderIndex(4, 1, 4, 5), 1);
+  assert.equal(remapReorderIndex(4, 1, 1, 5), 2);
+  assert.equal(remapReorderIndex(4, 1, 3, 5), 4);
+  // index=0 は影響を受けない
+  assert.equal(remapReorderIndex(4, 1, 0, 5), 0);
+});
+
+test("remapReorderIndex clamps out-of-range arguments", () => {
+  assert.equal(remapReorderIndex(99, 99, 99, 4), 3);
+  assert.equal(remapReorderIndex(-5, -5, -5, 4), 0);
+});
+
+test("remapReorderIndex returns 0 for empty data", () => {
+  assert.equal(remapReorderIndex(0, 0, 0, 0), 0);
+});
+
+test("remapReorderIndex is identity when source equals targetInsertIndex (no-op move)", () => {
+  // 同位置への挿入は実質 no-op として元の index をそのまま返すこと
+  for (let i = 0; i < 5; i += 1) {
+    assert.equal(remapReorderIndex(2, 2, i, 5), i);
+  }
+});
+
+test("remapReorderIndex is identity when target is just after source (no-op move)", () => {
+  // source=2 を target=3 (= source の直後) に動かしても同位置となる
+  for (let i = 0; i < 5; i += 1) {
+    assert.equal(remapReorderIndex(2, 3, i, 5), i);
+  }
+});
+
+test("remapSelectionForRowReorder returns null for null selection", () => {
+  assert.equal(remapSelectionForRowReorder(null, 1, 4, 5), null);
+});
+
+test("remapSelectionForRowReorder remaps row selection directly", () => {
+  // 5 body 行で row=2 を選択中、row=1 を row=4 へ動かすと selection は row=1 に詰まる
+  assert.deepEqual(remapSelectionForRowReorder({ kind: "row", row: 2 }, 1, 4, 5), {
+    kind: "row",
+    row: 1,
+  });
+});
+
+test("remapSelectionForRowReorder leaves header cell unchanged", () => {
+  // row=0 (header) は body reorder の影響を受けない
+  const sel = { kind: "cell" as const, row: 0, col: 1 };
+  assert.deepEqual(remapSelectionForRowReorder(sel, 1, 4, 5), sel);
+});
+
+test("remapSelectionForRowReorder remaps body cell using body index space", () => {
+  // 5 body 行で cell row=3 (body index=2) が選択。row 1 を row 4 に動かすと
+  // body index 2 -> 1、cell row は +1 して 2
+  assert.deepEqual(
+    remapSelectionForRowReorder({ kind: "cell", row: 3, col: 1 }, 1, 4, 5),
+    { kind: "cell", row: 2, col: 1 }
+  );
+});
+
+test("remapSelectionForRowReorder ignores column selection", () => {
+  const sel = { kind: "column" as const, col: 2 };
+  assert.deepEqual(remapSelectionForRowReorder(sel, 1, 4, 5), sel);
+});
+
+test("remapSelectionForColReorder remaps column and cell col", () => {
+  assert.deepEqual(
+    remapSelectionForColReorder({ kind: "column", col: 2 }, 1, 4, 5),
+    { kind: "column", col: 1 }
+  );
+  assert.deepEqual(
+    remapSelectionForColReorder({ kind: "cell", row: 3, col: 2 }, 1, 4, 5),
+    { kind: "cell", row: 3, col: 1 }
+  );
+});
+
+test("remapSelectionForColReorder leaves row selection alone", () => {
+  const sel = { kind: "row" as const, row: 1 };
+  assert.deepEqual(remapSelectionForColReorder(sel, 1, 4, 5), sel);
+});
+
+test("remapSelectionForRowReorder is defensive when bodyRowCount is 0", () => {
+  // 実コード上は到達しない経路だが、純粋関数として defensive に動く確認。
+  // remapReorderIndex は totalCount<=0 のとき 0 を返すため、body cell は row=1 にクランプされる。
+  assert.deepEqual(
+    remapSelectionForRowReorder({ kind: "cell", row: 1, col: 0 }, 0, 0, 0),
+    { kind: "cell", row: 1, col: 0 }
+  );
+  assert.deepEqual(
+    remapSelectionForRowReorder({ kind: "row", row: 0 }, 0, 0, 0),
+    { kind: "row", row: 0 }
+  );
+});
+
+test("remapSelectionForColReorder is defensive when columnCount is 0", () => {
+  assert.deepEqual(
+    remapSelectionForColReorder({ kind: "cell", row: 1, col: 0 }, 0, 0, 0),
+    { kind: "cell", row: 1, col: 0 }
+  );
+  assert.deepEqual(
+    remapSelectionForColReorder({ kind: "column", col: 0 }, 0, 0, 0),
+    { kind: "column", col: 0 }
+  );
+});


### PR DESCRIPTION
## Summary

#134 phase 2。TableWidget の `toDOM` 内クロージャから `this` を参照しないロジックを独立モジュールに切り出し、独立単体テストでガード。`index.ts` は **2147 行 → 2049 行** に短縮。

### 切り出した純粋関数

| 新規ファイル | 切り出した関数 | 引数化したクロージャ変数 |
|---|---|---|
| `src/tableHandleIcon.ts` | `createDragIndicatorIcon` | (なし) |
| `src/tableCellSelection.ts` | `clampCell` / `defaultCellSelection` / `moveCellByOffset` | `totalRows`, `columnCount`, `bodyRowCount` |
| `src/tableReorder.ts` | `remapReorderIndex` (旧 remapRowIndex/ColIndex の共通実装) / `remapSelectionForRowReorder` / `remapSelectionForColReorder` | `totalCount` (bodyRowCount or columnCount) |

### バグ修正を含む

`moveCellByOffset` の負方向 delta セマンティクスを `((x % m) + m) % m` 形式に修正しました。旧実装は `(flat + delta + totalCells) % totalCells` で、`delta < -totalCells` では JS の負剰余で row/col が負になる挙動でしたが、現状の呼び出し元では到達しないコードパスでした。テスト名にバグ修正の旨を明記しています。

### テスト追加 (+24 件)

- `tests/tableCellSelection.test.ts` (8 件): 境界値クランプ・wrap-around・空 grid・負 delta バグ修正の固定化
- `tests/tableReorder.test.ts` (16 件): 順方向/逆方向 reorder・no-op (同位置/隣接) ケース・defensive な空データ対応

`tableReorder.ts` の `CellSelection` は `tableCellSelection.ts` の `TableCellSelection` を import して共有することで、phase 3 までの間に型が乖離するリスクを排除しています。

## 動作確認 (playwright-cli)

- console error 0 件
- ハンドルアイコン SVG (drag indicator) が 5 個描画され `viewBox="0 0 24 24"` も正常
- テーブル focus → ArrowDown → Tab → Shift+Tab で wrap-around 含むセル移動が動作 (Header の最右端まで戻る)

## Test plan

- [x] `pnpm typecheck` / `pnpm lint`
- [x] `pnpm -C packages/core/cm6-table test` (84 件成功、+24)
- [x] `pnpm test:core`
- [x] `pnpm -C apps/webview-demo build`
- [x] playwright-cli で動作確認 (ハンドル表示・キーボードナビ・wrap-around)
- [x] Codex レビュー実施 → 指摘 4 件 (バグ修正明示、空データテスト、型乖離対策、no-op 境界テスト) を全件反映

Refs #130 #134
Closes #139

> Note: ベースを #138 (`refactor/130-4-tidy-table-shell`) にしています。順次マージで `main` へ向けてください。
> phase 3 以降 (DOM 操作系・selection 状態管理・drag/drop・context menu・edit lifecycle) は別 Issue で段階的に対応します。