### PR TITLE
refactor: cm6-table の selection 型を集約し純粋ロジックを切り出し (#141)

### DIFF
--- a/packages/core/cm6-table/src/index.ts
+++ b/packages/core/cm6-table/src/index.ts
@@ -62,33 +62,19 @@ import {
 import {
   clampCell as clampCellPure,
   defaultCellSelection as defaultCellSelectionPure,
+  ensureCellSelection as ensureCellSelectionPure,
   moveCellByOffset as moveCellByOffsetPure,
 } from "./tableCellSelection";
 import { createDragIndicatorIcon } from "./tableHandleIcon";
+import { findHoveredCellInEvent, isTableHandleElement } from "./tableHoverTarget";
 import {
   remapSelectionForColReorder as remapSelectionForColReorderPure,
   remapSelectionForRowReorder as remapSelectionForRowReorderPure,
 } from "./tableReorder";
+import type { CellSelection, SelectionState } from "./tableSelectionTypes";
 
 export type { TableAlignment, TableData, TableEditorOptions };
 
-type CellSelection = {
-  kind: "cell";
-  row: number;
-  col: number;
-};
-
-type RowSelection = {
-  kind: "row";
-  row: number;
-};
-
-type ColumnSelection = {
-  kind: "column";
-  col: number;
-};
-
-type SelectionState = CellSelection | RowSelection | ColumnSelection;
 
 type MenuState =
   | {
@@ -377,28 +363,6 @@ class TableWidget extends WidgetType {
       );
     };
 
-    const isHandleElement = (node: unknown) =>
-      node instanceof Element &&
-      !!node.closest(".cm-table-col-handle, .cm-table-row-handle");
-
-    const findHoveredCellInEvent = (
-      event: PointerEvent | MouseEvent
-    ): HTMLTableCellElement | null => {
-      const path = event.composedPath();
-      for (const node of path) {
-        if (isHandleElement(node)) {
-          return null;
-        }
-        if (!(node instanceof Element)) {
-          continue;
-        }
-        const cell = node.closest<HTMLTableCellElement>(".cm-table-cell");
-        if (cell) {
-          return cell;
-        }
-      }
-      return null;
-    };
 
     const updateRangeOutline = () => {
       selectionOutline.dataset.open = "false";
@@ -805,18 +769,17 @@ class TableWidget extends WidgetType {
     };
 
     const ensureCellSelection = (): CellSelection => {
+      const next = ensureCellSelectionPure(
+        selection,
+        data.rows.length,
+        getTotalRows(),
+        columnCount
+      );
+      // 旧実装: selection が null の場合のみ「保存」していた副作用を踏襲する。
       if (!selection) {
-        const next = defaultCellSelection();
         setSelection(next, false);
-        return next;
       }
-      if (selection.kind === "cell") {
-        return clampCell(selection.row, selection.col);
-      }
-      if (selection.kind === "row") {
-        return clampCell(selection.row + 1, 0);
-      }
-      return clampCell(data.rows.length > 0 ? 1 : 0, selection.col);
+      return next;
     };
 
     const positionEditor = (cell: CellSelection) => {
@@ -1279,7 +1242,7 @@ class TableWidget extends WidgetType {
     };
 
     const updateHoveredHandlesFromPointerEvent = (event: PointerEvent | MouseEvent) => {
-      if (isHandleElement(event.target)) {
+      if (isTableHandleElement(event.target)) {
         return;
       }
       const cell = findHoveredCellInEvent(event);
@@ -1337,7 +1300,7 @@ class TableWidget extends WidgetType {
     wrapper.addEventListener(
       "pointerleave",
       (event) => {
-        if (isHandleElement(event.relatedTarget)) {
+        if (isTableHandleElement(event.relatedTarget)) {
           return;
         }
         clearHoveredHandles();

--- a/packages/core/cm6-table/src/tableCellSelection.ts
+++ b/packages/core/cm6-table/src/tableCellSelection.ts
@@ -1,13 +1,8 @@
 import { clampCellSelection } from "./tableEditing";
+import type { CellSelection, SelectionState } from "./tableSelectionTypes";
 
-// TableWidget 内部の selection 型と同一構造。
-// (#134 phase 3 で SelectionState 全体を別ファイルに移すまで、ここで cell 選択のみ
-//  ローカル型として持っておく。RowSelection / ColumnSelection は本ファイルでは扱わない)
-export type TableCellSelection = {
-  kind: "cell";
-  row: number;
-  col: number;
-};
+// 後方互換のための alias。新規コードでは `CellSelection` を直接使うこと。
+export type TableCellSelection = CellSelection;
 
 // 行・列のサイズに収まるよう座標をクランプし、CellSelection を返す。
 export function clampCell(
@@ -15,7 +10,7 @@ export function clampCell(
   nextCol: number,
   totalRows: number,
   columnCount: number
-): TableCellSelection {
+): CellSelection {
   return {
     kind: "cell",
     ...clampCellSelection(nextRow, nextCol, totalRows, columnCount),
@@ -27,18 +22,18 @@ export function defaultCellSelection(
   bodyRowCount: number,
   totalRows: number,
   columnCount: number
-): TableCellSelection {
+): CellSelection {
   return clampCell(bodyRowCount > 0 ? 1 : 0, 0, totalRows, columnCount);
 }
 
 // 平坦化 (row * columnCount + col) されたインデックスで delta セル分移動する。
 // オフセット計算は totalRows * columnCount でラップする。
 export function moveCellByOffset(
-  current: TableCellSelection,
+  current: CellSelection,
   delta: number,
   totalRows: number,
   columnCount: number
-): TableCellSelection {
+): CellSelection {
   const totalCells = totalRows * columnCount;
   if (totalCells === 0) {
     return current;
@@ -48,4 +43,32 @@ export function moveCellByOffset(
   const nextRow = Math.floor(nextFlat / columnCount);
   const nextCol = nextFlat % columnCount;
   return { kind: "cell", row: nextRow, col: nextCol };
+}
+
+// 任意の selection を cell selection に昇格させる純粋関数。
+// - selection が null の場合は default cell selection (テーブル空なら header 行) を返す
+// - selection が cell の場合は範囲内へクランプ
+// - selection が row の場合はその行 +1 (header の次) の col 0 を選択
+// - selection が column の場合は最初の body 行 (空なら header) の同じ col を選択
+export function ensureCellSelection(
+  current: SelectionState | null,
+  bodyRowCount: number,
+  totalRows: number,
+  columnCount: number
+): CellSelection {
+  if (!current) {
+    return defaultCellSelection(bodyRowCount, totalRows, columnCount);
+  }
+  if (current.kind === "cell") {
+    return clampCell(current.row, current.col, totalRows, columnCount);
+  }
+  if (current.kind === "row") {
+    return clampCell(current.row + 1, 0, totalRows, columnCount);
+  }
+  return clampCell(
+    bodyRowCount > 0 ? 1 : 0,
+    current.col,
+    totalRows,
+    columnCount
+  );
 }

--- a/packages/core/cm6-table/src/tableHoverTarget.ts
+++ b/packages/core/cm6-table/src/tableHoverTarget.ts
@@ -1,0 +1,30 @@
+// pointer/mouse イベントの composedPath を辿り、ターゲットになっている
+// `.cm-table-cell` 要素を返す純粋ユーティリティ。
+// 行/列ハンドル要素 (`.cm-table-col-handle` / `.cm-table-row-handle`) を
+// 経由しているイベントは「セル外」とみなして null を返す。
+
+export function isTableHandleElement(node: unknown): boolean {
+  return (
+    node instanceof Element &&
+    !!node.closest(".cm-table-col-handle, .cm-table-row-handle")
+  );
+}
+
+export function findHoveredCellInEvent(
+  event: PointerEvent | MouseEvent
+): HTMLTableCellElement | null {
+  const path = event.composedPath();
+  for (const node of path) {
+    if (isTableHandleElement(node)) {
+      return null;
+    }
+    if (!(node instanceof Element)) {
+      continue;
+    }
+    const cell = node.closest<HTMLTableCellElement>(".cm-table-cell");
+    if (cell) {
+      return cell;
+    }
+  }
+  return null;
+}

--- a/packages/core/cm6-table/src/tableReorder.ts
+++ b/packages/core/cm6-table/src/tableReorder.ts
@@ -5,6 +5,8 @@
 // `targetInsertIndex`: 挿入したい位置 (元の配列での「この位置の前」を指す)
 // `index`: 追従計算したい既存の選択座標
 
+import type { SelectionState } from "./tableSelectionTypes";
+
 // reorder 後のインデックスを再計算する。範囲外は最も近い有効インデックスへクランプ。
 export function remapReorderIndex(
   sourceIndex: number,
@@ -33,17 +35,6 @@ export function remapReorderIndex(
     ? clampedIndex + 1
     : clampedIndex;
 }
-
-import type { TableCellSelection } from "./tableCellSelection";
-
-// SelectionState (内部型) と同一構造の最小定義。
-// CellSelection は tableCellSelection.ts と共有することで型の乖離を防ぐ。
-// RowSelection / ColumnSelection は #134 phase 3 で selection 全体を別ファイルに
-// 移すまで本ファイル内ローカル型で保持する。
-type CellSelection = TableCellSelection;
-type RowSelection = { kind: "row"; row: number };
-type ColumnSelection = { kind: "column"; col: number };
-type SelectionState = CellSelection | RowSelection | ColumnSelection;
 
 // 行 reorder に対して selection を追従。
 // - row selection: そのまま remap

--- a/packages/core/cm6-table/src/tableSelectionTypes.ts
+++ b/packages/core/cm6-table/src/tableSelectionTypes.ts
@@ -1,0 +1,20 @@
+// TableWidget 内の selection 状態の型定義。
+// 以前は index.ts と tableCellSelection.ts / tableReorder.ts に分散していた。
+
+export type CellSelection = {
+  kind: "cell";
+  row: number;
+  col: number;
+};
+
+export type RowSelection = {
+  kind: "row";
+  row: number;
+};
+
+export type ColumnSelection = {
+  kind: "column";
+  col: number;
+};
+
+export type SelectionState = CellSelection | RowSelection | ColumnSelection;

--- a/packages/core/cm6-table/tests/tableCellSelection.test.ts
+++ b/packages/core/cm6-table/tests/tableCellSelection.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   clampCell,
   defaultCellSelection,
+  ensureCellSelection,
   moveCellByOffset,
 } from "../src/tableCellSelection";
 
@@ -51,4 +52,65 @@ test("moveCellByOffset handles delta larger than total cells (fixes negative-mod
 test("moveCellByOffset returns current selection when grid is empty", () => {
   const cur = { kind: "cell" as const, row: 0, col: 0 };
   assert.deepEqual(moveCellByOffset(cur, 1, 0, 0), cur);
+});
+
+test("ensureCellSelection returns default cell when current is null", () => {
+  assert.deepEqual(ensureCellSelection(null, 2, 3, 2), {
+    kind: "cell",
+    row: 1,
+    col: 0,
+  });
+});
+
+test("ensureCellSelection clamps existing cell selection to grid bounds", () => {
+  // 範囲外を渡してもクランプされる
+  assert.deepEqual(
+    ensureCellSelection({ kind: "cell", row: 5, col: 9 }, 2, 3, 2),
+    { kind: "cell", row: 2, col: 1 }
+  );
+});
+
+test("ensureCellSelection promotes row selection to first cell of that body row", () => {
+  // row=1 は body の 2 番目 → header の次にあたるので row=2, col=0
+  assert.deepEqual(ensureCellSelection({ kind: "row", row: 1 }, 3, 4, 2), {
+    kind: "cell",
+    row: 2,
+    col: 0,
+  });
+});
+
+test("ensureCellSelection promotes column selection to first body row of that column", () => {
+  // body 行があるので row=1, col は維持
+  assert.deepEqual(ensureCellSelection({ kind: "column", col: 1 }, 2, 3, 2), {
+    kind: "cell",
+    row: 1,
+    col: 1,
+  });
+});
+
+test("ensureCellSelection from column falls back to header when no body rows", () => {
+  // body 行 0 のときは header (row=0) を選ぶ
+  assert.deepEqual(ensureCellSelection({ kind: "column", col: 0 }, 0, 1, 2), {
+    kind: "cell",
+    row: 0,
+    col: 0,
+  });
+});
+
+test("ensureCellSelection clamps out-of-range row selection during promotion", () => {
+  // row=99 が来ても row+1=100 は totalRows-1 にクランプされる
+  assert.deepEqual(ensureCellSelection({ kind: "row", row: 99 }, 2, 3, 2), {
+    kind: "cell",
+    row: 2,
+    col: 0,
+  });
+});
+
+test("ensureCellSelection clamps out-of-range column selection during promotion", () => {
+  // col=99 はクランプされて columnCount-1
+  assert.deepEqual(ensureCellSelection({ kind: "column", col: 99 }, 2, 3, 2), {
+    kind: "cell",
+    row: 1,
+    col: 1,
+  });
 });

--- a/packages/core/cm6-table/tests/tableHoverTarget.test.ts
+++ b/packages/core/cm6-table/tests/tableHoverTarget.test.ts
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  findHoveredCellInEvent,
+  isTableHandleElement,
+} from "../src/tableHoverTarget";
+
+// 最小限の DOM mock。`closest` は祖先を辿って match する要素を返す
+// 実ブラウザ準拠の挙動を再現する (子→親→...→祖先のいずれかが match すれば返す)。
+type FakeElement = {
+  parent: FakeElement | null;
+  classes: Set<string>;
+  classList: { contains: (name: string) => boolean };
+  closest: (selector: string) => FakeElement | null;
+};
+
+function makeFakeElement(classes: string[], parent: FakeElement | null = null): FakeElement {
+  const set = new Set(classes);
+  const el: FakeElement = {
+    parent,
+    classes: set,
+    classList: {
+      contains: (name: string) => set.has(name),
+    },
+    closest: (selector: string) => {
+      const wanted = selector
+        .split(",")
+        .map((s) => s.trim().replace(/^\./, ""));
+      let cur: FakeElement | null = el;
+      while (cur) {
+        if (wanted.some((cls) => cur!.classes.has(cls))) {
+          return cur;
+        }
+        cur = cur.parent;
+      }
+      return null;
+    },
+  };
+  return el;
+}
+
+// `instanceof Element` 判定を通すための一時的な Element コンストラクタ差し替え。
+// node.js 環境には Element が無いので、テスト中だけ差し替える。
+function withFakeElement<T>(run: () => T): T {
+  const original = (globalThis as { Element?: unknown }).Element;
+  class FakeElementCtor {}
+  (globalThis as { Element?: unknown }).Element = FakeElementCtor;
+  try {
+    return run();
+  } finally {
+    if (original === undefined) {
+      delete (globalThis as { Element?: unknown }).Element;
+    } else {
+      (globalThis as { Element?: unknown }).Element = original;
+    }
+  }
+}
+
+function makeElementInstance(
+  classes: string[],
+  parent: FakeElement | null = null
+): FakeElement {
+  const fake = makeFakeElement(classes, parent);
+  const Element = (globalThis as { Element?: { prototype?: object } }).Element;
+  if (Element?.prototype) {
+    Object.setPrototypeOf(fake, Element.prototype);
+  }
+  return fake;
+}
+
+test("isTableHandleElement returns true for handle elements themselves", () => {
+  withFakeElement(() => {
+    const colHandle = makeElementInstance(["cm-table-col-handle"]);
+    const rowHandle = makeElementInstance(["cm-table-row-handle"]);
+    assert.equal(isTableHandleElement(colHandle), true);
+    assert.equal(isTableHandleElement(rowHandle), true);
+  });
+});
+
+test("isTableHandleElement returns true for descendants of a handle", () => {
+  withFakeElement(() => {
+    const handle = makeElementInstance(["cm-table-col-handle"]);
+    const handleIcon = makeElementInstance(["cm-table-handle-icon"], handle);
+    const handleIconChild = makeElementInstance([], handleIcon);
+    assert.equal(isTableHandleElement(handleIcon), true);
+    assert.equal(isTableHandleElement(handleIconChild), true);
+  });
+});
+
+test("isTableHandleElement returns false for unrelated elements and non-Element values", () => {
+  withFakeElement(() => {
+    const cell = makeElementInstance(["cm-table-cell"]);
+    assert.equal(isTableHandleElement(cell), false);
+    assert.equal(isTableHandleElement(null), false);
+    assert.equal(isTableHandleElement("string"), false);
+    assert.equal(isTableHandleElement({ notAnElement: true }), false);
+  });
+});
+
+test("findHoveredCellInEvent walks ancestors via closest to find the cell", () => {
+  withFakeElement(() => {
+    const cellEl = makeElementInstance(["cm-table-cell"]);
+    const cellContent = makeElementInstance(["cm-table-cell-content"], cellEl);
+    const innerSpan = makeElementInstance(["inner-text"], cellContent);
+    // event.target は子孫 (innerSpan) であっても祖先の cell を返す
+    const event = {
+      composedPath: () => [innerSpan, cellContent, cellEl],
+    } as unknown as PointerEvent;
+    assert.equal(findHoveredCellInEvent(event), cellEl);
+  });
+});
+
+test("findHoveredCellInEvent returns null when path includes a handle descendant before any cell", () => {
+  withFakeElement(() => {
+    // handle の子要素から発火したイベント。cell も path にあるが先に handle が見つかるので null
+    const handle = makeElementInstance(["cm-table-col-handle"]);
+    const handleIcon = makeElementInstance(["cm-table-handle-icon"], handle);
+    const cellEl = makeElementInstance(["cm-table-cell"]);
+    const event = {
+      composedPath: () => [handleIcon, handle, cellEl],
+    } as unknown as PointerEvent;
+    assert.equal(findHoveredCellInEvent(event), null);
+  });
+});
+
+test("findHoveredCellInEvent returns null when no cell is in the path", () => {
+  withFakeElement(() => {
+    const other = makeElementInstance(["cm-content"]);
+    const event = {
+      composedPath: () => [other],
+    } as unknown as PointerEvent;
+    assert.equal(findHoveredCellInEvent(event), null);
+  });
+});
+
+test("findHoveredCellInEvent skips non-Element entries (e.g. window/document)", () => {
+  withFakeElement(() => {
+    const cellEl = makeElementInstance(["cm-table-cell"]);
+    const event = {
+      composedPath: () => [{ notAnElement: true }, cellEl],
+    } as unknown as PointerEvent;
+    assert.equal(findHoveredCellInEvent(event), cellEl);
+  });
+});


### PR DESCRIPTION
## Summary

#134 phase 3。TableWidget の selection 関連を整理し、`index.ts` は **2049 → 2012 行** に短縮。

### 切り出した内容

| ファイル | 内容 |
|---|---|
| `src/tableSelectionTypes.ts` (新規) | `CellSelection` / `RowSelection` / `ColumnSelection` / `SelectionState` を集約 (旧: index.ts, tableCellSelection.ts, tableReorder.ts に分散) |
| `src/tableCellSelection.ts` | `TableCellSelection` を `CellSelection` の alias に変更 (後方互換)。`ensureCellSelection` を純粋関数として追加 |
| `src/tableReorder.ts` | ローカル selection 型を削除し `tableSelectionTypes` から import するだけに整理 |
| `src/tableHoverTarget.ts` (新規) | `findHoveredCellInEvent` と `isTableHandleElement` を切り出し |

### index.ts の変更

- selection 型定義を削除し import 化
- `ensureCellSelection` を純粋版を呼ぶ薄ラッパに置換 (selection が null のときだけ `setSelection` 副作用を保つ動作を維持)
- `findHoveredCellInEvent` / `isHandleElement` を新モジュールから import (isHandleElement → isTableHandleElement に rename、3 箇所の呼び出しを置換)

### テスト追加 (+14 件、cm6-table 全体で 98 件)

- `tableCellSelection.test.ts`: `ensureCellSelection` を 7 ケース追加 (null/cell/row/column/column→header fallback/row 範囲外 clamp/column 範囲外 clamp)
- `tableHoverTarget.test.ts` (新規): 7 ケース。closest が祖先を辿る実ブラウザ準拠の挙動を mock で再現し、handle/cell の子孫から親要素が解決されるケースもカバー

## 動作確認 (playwright-cli)

- webview-demo の table widget を開き、Tab/Shift+Tab で wrap-around 含むセル移動が回帰なく動作
- console error 0 件

## Test plan

- [x] `pnpm typecheck` / `pnpm lint`
- [x] `pnpm -C packages/core/cm6-table test` (98 件成功、+14)
- [x] `pnpm -C apps/webview-demo build`
- [x] playwright-cli で動作確認 (キーボードナビゲーション)
- [x] Codex レビュー実施 → 指摘 (DOM mock の祖先辿り対応、row/column 範囲外 clamp テスト追加) を反映済み

Refs #130 #134
Closes #141

> Note: ベースは `main` (#140 までマージ済み)。

phase 4 以降 (DOM 操作系: applySelectionClasses / updateRangeOutline / updateHandlePositions、edit lifecycle、drag/drop、context menu) は別 Issue で段階的に対応します。